### PR TITLE
Cleanup: help-screen typos (#13), IRE docs (#3), GHA action bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout
         if: steps.filter.outputs.skip == 'false'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Lowercase image name
         if: steps.filter.outputs.skip == 'false'
@@ -54,7 +54,7 @@ jobs:
 
       - name: Log in to GHCR (read)
         if: steps.filter.outputs.skip == 'false'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload artifact
         if: steps.filter.outputs.skip == 'false'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.stage.outputs.name }}
           path: ${{ steps.stage.outputs.outdir }}/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.meta.outputs.tag }}
           fetch-depth: 0
@@ -53,7 +53,7 @@ jobs:
         run: echo "SDK_IMAGE=$(echo $SDK_IMAGE | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR (read)
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -94,7 +94,7 @@ jobs:
           ls -lh "$OUTDIR"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-${{ steps.meta.outputs.tag }}
           path: dist/${{ env.PROJECT }}-${{ steps.meta.outputs.tag }}/*
@@ -111,19 +111,19 @@ jobs:
       PROJECT: jag_240p_test_suite
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.build.outputs.tag }}
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-${{ needs.build.outputs.tag }}
           path: release/
 
       - name: Publish release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.build.outputs.tag }}
           name: ${{ needs.build.outputs.tag }}

--- a/.github/workflows/sdk-image.yml
+++ b/.github/workflows/sdk-image.yml
@@ -31,18 +31,18 @@ jobs:
       IMAGE: ghcr.io/${{ github.repository_owner }}/jaguar-sdk
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Lowercase image name
         id: img
         run: echo "image=$(echo ${IMAGE} | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -81,7 +81,7 @@ jobs:
           fi
 
       - name: Build${{ steps.mode.outputs.push == 'true' && ' & push' || '' }} SDK image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: docker
           file: docker/Dockerfile

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -1306,20 +1306,27 @@ void BouncingSquareSaver(void){
     uint16_t *sqData = malloc(sizeof(uint16_t)*sw*sh);
     for(i = 0; i < sw*sh; i++){ sqData[i] = white; }
 
+    /* Layer state on entry: the menu has just hidden every layer it owns,
+     * so by default *no* layer is visible -- attaching to layer 12 is not
+     * enough on its own, we still have to explicitly hide_or_show it.
+     * Hide everything first as a known-good baseline, then bring up only
+     * the two layers we actually use (12 = bouncing square, 13 = help
+     * text). The previous version skipped the layer-12 show and so the
+     * sprite was attached but invisible -- pure black screen. */
+    hide_or_show_display_layer_range(settings->d, 0, 0, 15);
+
     sprite *sq = new_sprite(sw, sh, 80, 80, DEPTH16, (uint8_t*)sqData);
     /* Match every other DEPTH16 sprite in the project -- new_sprite()'s
      * default trans is non-zero, which would otherwise punch holes through
      * texels that happen to match the magic transparent value. */
     sq->trans = 0;
     attach_sprite_to_display_at_layer(sq, settings->d, 12);
+    hide_or_show_display_layer_range(settings->d, 1, 12, 12);
 
     int vx = 2;
     int vy = 1;
     int x = 80;
     int y = 80;
-
-    hide_or_show_display_layer_range(settings->d, 0, 0, 11);
-    hide_or_show_display_layer_range(settings->d, 0, 13, 15);
 
     textBox *helpTb = newTextBox("OPTION: exit", 128, 9, mainFont, 0, settings->d, 96, 8, 13, 1);
     updateLine(settings, mainFont, helpTb, NULL, 999999, 999999, GREY);
@@ -1353,7 +1360,9 @@ void BouncingSquareSaver(void){
     free(sq);
     free(sqData);
 
-    hide_or_show_display_layer_range(settings->d, 0, 13, 13);
+    /* Hide the saver-owned layers, then re-show every layer so the menu
+     * (layers 0-11) is visible again on return. Matches ColorCycleSaver. */
+    hide_or_show_display_layer_range(settings->d, 0, 12, 13);
     hide_or_show_display_layer_range(settings->d, 1, 0, 15);
     helpTb = freeTextBox(helpTb);
 }
@@ -1410,19 +1419,24 @@ void ScrollingBarsSaver(void){
         }
     }
 
+    /* Same layer-state baseline as BouncingSquareSaver: hide everything,
+     * then bring up only the layers we need. Without an explicit show on
+     * layer 12 the sprites attach but never become visible (the menu had
+     * everything hidden) -- previously caused a black screen. */
+    hide_or_show_display_layer_range(settings->d, 0, 0, 15);
+
     /* Two sprites, identical pixel source, x positions kept 320 apart so
      * the visible scroll is always covered. trans=0 for both -- DEPTH16
      * fullscreen sprites in this project always disable trans (matches
-     * Draw100IRE, DrawWhiteScreen, all the new procedural patterns). */
+     * Draw100IRE, DrawWhiteScreen, all the new procedural patterns).
+     * Both sprites share layer 12 -- a single show call covers both. */
     sprite *fbS1 = new_sprite(320, screenH, 0,   0, DEPTH16, (uint8_t*)fb);
     fbS1->trans = 0;
     attach_sprite_to_display_at_layer(fbS1, settings->d, 12);
     sprite *fbS2 = new_sprite(320, screenH, 320, 0, DEPTH16, (uint8_t*)fb);
     fbS2->trans = 0;
     attach_sprite_to_display_at_layer(fbS2, settings->d, 12);
-
-    hide_or_show_display_layer_range(settings->d, 0, 0, 11);
-    hide_or_show_display_layer_range(settings->d, 0, 13, 15);
+    hide_or_show_display_layer_range(settings->d, 1, 12, 12);
 
     textBox *helpTb = newTextBox("A: reverse  OPTION: exit", 192, 9, mainFont, 0, settings->d, 64, 8, 13, 1);
     updateLine(settings, mainFont, helpTb, NULL, 999999, 999999, GREY);
@@ -1466,7 +1480,9 @@ void ScrollingBarsSaver(void){
     free(fbS2);
     free(fb);
 
-    hide_or_show_display_layer_range(settings->d, 0, 13, 13);
+    /* Hide saver-owned layers, then re-show every layer so the menu
+     * (layers 0-11) is visible again on return. */
+    hide_or_show_display_layer_range(settings->d, 0, 12, 13);
     hide_or_show_display_layer_range(settings->d, 1, 0, 15);
     helpTb = freeTextBox(helpTb);
 }

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -1273,12 +1273,16 @@ void ColorCycleSaver(void){
 /* ---------------------------------------------------------------------------
  * Screen Saver: Bouncing Square
  *
- * A 32x32 white sprite that bounces around the active area on a fixed
- * trajectory, similar to the classic DVD logo screen saver. Forces every
- * pixel of the panel to light up at least once over a few minutes, which
- * is the canonical OLED burn-in mitigation use case. The bounce trail
- * is intentionally NOT drawn so that any latent pixels show up against
- * the otherwise-black background.
+ * A 32x32 DEPTH16 white sprite that bounces around the active area on a
+ * fixed trajectory, similar to the classic DVD logo screen saver. Forces
+ * every pixel of the panel to light up at least once over a few minutes,
+ * which is the canonical OLED burn-in mitigation use case. The bounce
+ * trail is intentionally NOT drawn so that any latent pixels show up
+ * against the otherwise-black background.
+ *
+ * Implementation note: uses DEPTH16 with explicit RGB16 white (0xFFFF)
+ * rather than DEPTH8 + CLUT lookup, so the saver doesn't depend on
+ * (or have to restore) any particular state in TOMREGS->clut1.
  *
  * Controls: OPTION = exit. Velocity is hard-coded; A presses do nothing
  * by design (any sub-frame button latency would bias the trajectory).
@@ -1290,16 +1294,22 @@ void BouncingSquareSaver(void){
     const int sh = 32;
     const int screenH = (settings->PALNTSC > 0) ? 240 : 288;
 
-    /* 32x32 DEPTH8 sprite filled with CLUT entry 1 (white in the default
-     * background palette). Allocated heap-side so we can free it cleanly
-     * on exit; the static-LED test does the same thing for consistency. */
-    uint8_t *sqData = malloc(sizeof(uint8_t)*sw*sh);
-    for(i = 0; i < sw*sh; i++){ sqData[i] = 0x01; }
+    /* 32x32 DEPTH16 sprite filled with explicit white = R5+B5+G6 all max.
+     *
+     * The earlier DEPTH8 implementation indexed CLUT entry 1, but the menu
+     * doesn't guarantee any particular value at TOMREGS->clut1[1] (the LED
+     * test in tests.c explicitly populates clut1 entries; we'd have had to
+     * do the same and then restore the menu's CLUT on exit). Going DEPTH16
+     * with literal RGB16 pixels sidesteps the CLUT plumbing entirely and
+     * survives any future menu palette changes. */
+    const uint16_t white = (uint16_t)((31u << 11) | (31u << 6) | 63u);
+    uint16_t *sqData = malloc(sizeof(uint16_t)*sw*sh);
+    for(i = 0; i < sw*sh; i++){ sqData[i] = white; }
 
-    sprite *sq = new_sprite(sw, sh, 80, 80, DEPTH8, sqData);
-    /* Match every other sprite in extra_tests.c / patterns.c -- the new_sprite
-     * default for trans is non-zero, so without this the corner texels of the
-     * square render see-through depending on the BG palette. */
+    sprite *sq = new_sprite(sw, sh, 80, 80, DEPTH16, (uint8_t*)sqData);
+    /* Match every other DEPTH16 sprite in the project -- new_sprite()'s
+     * default trans is non-zero, which would otherwise punch holes through
+     * texels that happen to match the magic transparent value. */
     sq->trans = 0;
     attach_sprite_to_display_at_layer(sq, settings->d, 12);
 
@@ -1351,11 +1361,23 @@ void BouncingSquareSaver(void){
 /* ---------------------------------------------------------------------------
  * Screen Saver: Scrolling Color Bars
  *
- * Builds a single 320-pixel-wide horizontal rainbow strip in RGB16 and
- * scrolls its source X every frame so the bars appear to slide across
- * the screen. Doubles as a chroma-bleed / scroll-jitter eyeball test
- * because the color transitions never sit still long enough for the
- * display's color converter to settle on any one transition.
+ * Builds a single 320 x screenH RGB16 framebuffer of vertical rainbow bars
+ * and attaches it as TWO sprites side-by-side, both pointing at the same
+ * pixel data. Scrolling just nudges both sprite x positions in lockstep:
+ * as one slides off the left edge, the other slides in from the right.
+ * When the leading sprite has fully exited (sx hits -320), we snap sx
+ * back to 0 -- the picture is identical at sx=0 and sx=-320, so the seam
+ * is invisible.
+ *
+ * Doubles as a chroma-bleed / scroll-jitter eyeball test because the color
+ * transitions never sit still long enough for the display's color
+ * converter to settle on any one transition.
+ *
+ * The previous single-sprite implementation let sx range across [-320, 320]
+ * and so spent half its cycle with the sprite fully off-screen, which
+ * looked like a blank frame followed by a sudden snap. The two-sprite
+ * trick is the same idea every Genesis/SNES scrolling-background routine
+ * uses, just expressed via the Jaguar OP instead of an HW scroll register.
  *
  * Controls: A = reverse direction, OPTION = exit.
  * --------------------------------------------------------------------------- */
@@ -1365,14 +1387,14 @@ void ScrollingBarsSaver(void){
     int i, x;
     const int screenH = (settings->PALNTSC > 0) ? 240 : 288;
 
-    /* Allocate a 320 x screenH RGB16 framebuffer and fill with vertical
-     * rainbow bars. We rebuild the colors for each pixel-column so the
-     * scroll just nudges sprite->x and re-renders -- much cheaper than
-     * memmove'ing the whole buffer every frame. */
+    /* Single 320 x screenH RGB16 framebuffer. Both sprites read from this
+     * one buffer -- no need to double the memory just to get seamless
+     * wraparound. */
     uint16_t *fb = malloc(sizeof(uint16_t)*320*screenH);
 
     /* Six-color rainbow bars (R, Y, G, C, B, M) repeated to fill 320 wide.
-     * Each bar is ~53px so the cycle wraps cleanly at the screen edge. */
+     * Each bar is ~53px (320/6 = 53.3) so the cycle wraps cleanly at the
+     * screen edge -- both halves of the bar pair line up at sx == -320. */
     static const uint16_t bars[6] = {
         (uint16_t)((31<<11) | (0 <<6) | 0 ),    /* red    */
         (uint16_t)((31<<11) | (0 <<6) | 63),    /* yellow */
@@ -1388,13 +1410,16 @@ void ScrollingBarsSaver(void){
         }
     }
 
-    sprite *fbS = new_sprite(320, screenH, 0, 0, DEPTH16, (uint8_t*)fb);
-    /* DEPTH16 fullscreen sprites everywhere else in the project (Draw100IRE,
-     * DrawWhiteScreen, all five new procedural patterns...) explicitly disable
-     * trans; honor that contract here so the bars don't acquire transparent
-     * pixels if the sprite engine default ever changes. */
-    fbS->trans = 0;
-    attach_sprite_to_display_at_layer(fbS, settings->d, 12);
+    /* Two sprites, identical pixel source, x positions kept 320 apart so
+     * the visible scroll is always covered. trans=0 for both -- DEPTH16
+     * fullscreen sprites in this project always disable trans (matches
+     * Draw100IRE, DrawWhiteScreen, all the new procedural patterns). */
+    sprite *fbS1 = new_sprite(320, screenH, 0,   0, DEPTH16, (uint8_t*)fb);
+    fbS1->trans = 0;
+    attach_sprite_to_display_at_layer(fbS1, settings->d, 12);
+    sprite *fbS2 = new_sprite(320, screenH, 320, 0, DEPTH16, (uint8_t*)fb);
+    fbS2->trans = 0;
+    attach_sprite_to_display_at_layer(fbS2, settings->d, 12);
 
     hide_or_show_display_layer_range(settings->d, 0, 0, 11);
     hide_or_show_display_layer_range(settings->d, 0, 13, 15);
@@ -1403,6 +1428,11 @@ void ScrollingBarsSaver(void){
     updateLine(settings, mainFont, helpTb, NULL, 999999, 999999, GREY);
     hide_or_show_display_layer_range(settings->d, 1, 13, 13);
 
+    /* sx is the x position of the LEFT sprite; the right sprite always
+     * sits at sx + 320. Confined to (-320, 0]: when sx slides below
+     * -320, snap to 0 (right sprite has just become the left one). When
+     * scrolling the other direction, sx slides above 0 and we snap to
+     * -320 (left sprite has just become the right one). */
     int sx = 0;
     while(!exit){
         read_joypad_state(settings->j_state);
@@ -1410,9 +1440,10 @@ void ScrollingBarsSaver(void){
         vsync();
 
         sx += dir;
-        if(sx > 320)  sx = -320;
-        if(sx < -320) sx =  320;
-        fbS->x = sx;
+        if(sx <= -320) sx = 0;
+        if(sx >    0)  sx = -320;
+        fbS1->x = sx;
+        fbS2->x = sx + 320;
 
         if((settings->joy1 & 0xFFFFFF) == 0){
             settings->controllerLock = 0;
@@ -1427,9 +1458,12 @@ void ScrollingBarsSaver(void){
         }
     }
 
-    fbS->invisible = 1;
-    detach_sprite_from_display(fbS);
-    free(fbS);
+    fbS1->invisible = 1;
+    fbS2->invisible = 1;
+    detach_sprite_from_display(fbS1);
+    detach_sprite_from_display(fbS2);
+    free(fbS1);
+    free(fbS2);
     free(fb);
 
     hide_or_show_display_layer_range(settings->d, 0, 13, 13);

--- a/help.c
+++ b/help.c
@@ -42,9 +42,12 @@ static int helpStrstrIndex(const char *hay, const char *needle){
  *
  * No-op (and safe) if the phrase isn't found, e.g. after a future rewrite. */
 static void highlightHelpPhrase(textBox *tb, const char *phrase){
+    const char *base;
+    int start;
+
     if(tb == NULL || tb->text == NULL || phrase == NULL){ return; }
-    const char *base = (const char *)tb->text;
-    int start = helpStrstrIndex(base, phrase);
+    base = (const char *)tb->text;
+    start = helpStrstrIndex(base, phrase);
     if(start < 0){ return; }
     textRangeColorChange(tb, start, helpStrlen(phrase), WHITE, GREEN);
 }

--- a/help.c
+++ b/help.c
@@ -16,9 +16,9 @@ static int helpStrlen(const char *s){
 }
 
 static int helpStrstrIndex(const char *hay, const char *needle){
+    int i, j;
     if(hay == NULL || needle == NULL){ return -1; }
     if(needle[0] == '\0'){ return 0; }
-    int i, j;
     for(i = 0; hay[i] != '\0'; i++){
         for(j = 0; needle[j] != '\0' && hay[i + j] == needle[j]; j++){ /* match */ }
         if(needle[j] == '\0'){ return i; }

--- a/help.c
+++ b/help.c
@@ -1,5 +1,53 @@
 #include "./help.h"
 
+/* helpStrlen() / helpStrstr()
+ *
+ * Tiny in-house substring search. The Jaguar SDK's jlibc ships strlen() but
+ * not strstr(), so we roll our own naive O(n*m) scan. Only ever called
+ * during help-screen redraws on user-pressed OPTION+DOWN, so the
+ * worst-case ~360-char haystack search is irrelevant for performance.
+ * Returns the byte index of the first occurrence of `needle` in `hay`, or
+ * -1 if not found. NULL inputs are treated as not-found. */
+static int helpStrlen(const char *s){
+    int n = 0;
+    while(s[n] != '\0'){ n++; }
+    return n;
+}
+
+static int helpStrstrIndex(const char *hay, const char *needle){
+    if(hay == NULL || needle == NULL){ return -1; }
+    if(needle[0] == '\0'){ return 0; }
+    int i, j;
+    for(i = 0; hay[i] != '\0'; i++){
+        for(j = 0; needle[j] != '\0' && hay[i + j] == needle[j]; j++){ /* match */ }
+        if(needle[j] == '\0'){ return i; }
+        if(hay[i + j] == '\0'){ return -1; }
+    }
+    return -1;
+}
+
+/* highlightHelpPhrase()
+ *
+ * Recolors `phrase` inside `tb`'s currently-set text by locating it at
+ * runtime rather than by hard-coding a character offset.
+ *
+ * Rationale: textRangeColorChange() takes an absolute character index, so
+ * any edit to the surrounding help string (typo fix, rewording, translation)
+ * silently misaligns the highlight onto the wrong characters. Locating the
+ * substring at runtime keeps the highlight pinned to the intended phrase
+ * regardless of upstream edits. Caught by Qodo on PR #3 after the
+ * "Evalute" -> "Evaluate" + "procesors" -> "processors" typo fixes shifted
+ * "DOWN + OPTION" two characters to the right of its old offset (291).
+ *
+ * No-op (and safe) if the phrase isn't found, e.g. after a future rewrite. */
+static void highlightHelpPhrase(textBox *tb, const char *phrase){
+    if(tb == NULL || tb->text == NULL || phrase == NULL){ return; }
+    const char *base = (const char *)tb->text;
+    int start = helpStrstrIndex(base, phrase);
+    if(start < 0){ return; }
+    textRangeColorChange(tb, start, helpStrlen(phrase), WHITE, GREEN);
+}
+
 void DrawHelp(int option){
     
     int i = 0;
@@ -88,7 +136,7 @@ void DrawHelp(int option){
                             updateLine(settings, mainFont, helpLineTextBox[0], "HELP GENERAL (1/2)", 999999, 999999, GREEN);
                             
                             updateLine(settings, mainFont, helpTextBox, "The 240p Test Suite was designed with two goals in mind:^^1) Evaluate 240p signals on TV sets and video processors; and...^^2) provide calibration patterns from a game console to help in properly calibrating the display black, white and color levels.^^Help is available everywhere by pressing DOWN + OPTION.", 999999, 999999, WHITE);
-                            textRangeColorChange(helpTextBox, 291, 13, WHITE, GREEN);
+                            highlightHelpPhrase(helpTextBox, "DOWN + OPTION");
 
                             updateLine(settings, mainFont, helpLineTextBox[1], "Continued...", 999999, 999999, WHITE);
 
@@ -98,8 +146,8 @@ void DrawHelp(int option){
                             updateLine(settings, mainFont, helpLineTextBox[0], "HELP GENERAL (2/2)", 999999, 999999, GREEN);
                             
                             updateLine(settings, mainFont, helpTextBox, "The Jaguar port of the 240p Test Suite is a work in progress. Some functionality is still missing. For more information about the current state of this software, visit:^  https://jagcorner.com/240p-test-suite^^More general information about the 240p Test Suite:^  https://junkerhq.net/240p  ", 999999, 999999, WHITE);
-                            textRangeColorChange(helpTextBox, 171, 37, WHITE, GREEN);
-                            textRangeColorChange(helpTextBox, 264, 25, WHITE, GREEN);
+                            highlightHelpPhrase(helpTextBox, "https://jagcorner.com/240p-test-suite");
+                            highlightHelpPhrase(helpTextBox, "https://junkerhq.net/240p");
 
                         break;
                     }

--- a/help.c
+++ b/help.c
@@ -87,7 +87,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "HELP GENERAL (1/2)", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "The 240p Test Suite was designed with two goals in mind:^^1) Evalute 240p signals on TV sets and video procesors; and...^^2) provide calibration patterns from a game console to help in properly calibrating the display black, white and color levels.^^Help is available everywhere by pressing DOWN + OPTION.", 999999, 999999, WHITE);
+                            updateLine(settings, mainFont, helpTextBox, "The 240p Test Suite was designed with two goals in mind:^^1) Evaluate 240p signals on TV sets and video processors; and...^^2) provide calibration patterns from a game console to help in properly calibrating the display black, white and color levels.^^Help is available everywhere by pressing DOWN + OPTION.", 999999, 999999, WHITE);
                             textRangeColorChange(helpTextBox, 291, 13, WHITE, GREEN);
 
                             updateLine(settings, mainFont, helpLineTextBox[1], "Continued...", 999999, 999999, WHITE);
@@ -114,7 +114,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "PLUGE (1/3)", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "NTSC levels require black to beat 7.5 IRE for video. This HW lowest is 6 IRE (6%), so using this value for general 240p use is not recommended.^^Of course using it as reference will work perfectly for games in this platform.^^In PAL - and console gaming in general - it is advized to use a value of 2 IRE as black.", 999999, 999999, WHITE);
+                            updateLine(settings, mainFont, helpTextBox, "NTSC levels require black to beat 7.5 IRE for video. This HW lowest is 6 IRE (6%), so using this value for general 240p use is not recommended.^^Of course using it as reference will work perfectly for games in this platform.^^In PAL - and console gaming in general - it is advised to use a value of 2 IRE as black.", 999999, 999999, WHITE);
                             
                             updateLine(settings, mainFont, helpLineTextBox[1], "Continued...", 999999, 999999, WHITE);
                         break;
@@ -184,7 +184,7 @@ void DrawHelp(int option){
                         case 1:
                             updateLine(settings, mainFont, helpLineTextBox[0], "MONOSCOPE (2/3)", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "Convergence: Use the center crosshair to check static (center of screen) convergence. Use the patterns at the sides to check dynamic (edge) convergence.^^Corners: After setting center and edge convergence, use magnets to adjust corner purity and geomentry.", 999999, 999999, WHITE);
+                            updateLine(settings, mainFont, helpTextBox, "Convergence: Use the center crosshair to check static (center of screen) convergence. Use the patterns at the sides to check dynamic (edge) convergence.^^Corners: After setting center and edge convergence, use magnets to adjust corner purity and geometry.", 999999, 999999, WHITE);
                             
                             updateLine(settings, mainFont, helpLineTextBox[1], "Continued...", 999999, 999999, WHITE);
                         break;
@@ -206,7 +206,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "COLOR BLEED", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "This pattern helps diagnose color bleed caused by unneeded color upsampling.^^You can toggle between certical bars and checkerboard with 'A'.", 999999, 999999, WHITE);
+                            updateLine(settings, mainFont, helpTextBox, "This pattern helps diagnose color bleed caused by unneeded color upsampling.^^You can toggle between vertical bars and checkerboard with 'A'.", 999999, 999999, WHITE);
                         break;
                     }
                     
@@ -219,7 +219,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "100 IRE", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "You can vary IRE intensity with A and B. Values are: 13, 25, 41, 53, 66, 82, 94.", 999999, 999999, WHITE);        
+                            updateLine(settings, mainFont, helpTextBox, "You can vary IRE intensity with A and B. Values are: 13, 25, 41, 53, 66, 82, 94.^^Each step maps to (IRE/100) * 63 on the Jaguar's 6-bit green channel; red and blue are driven at half that to stay neutral.^^NTSC-J / PAL / PC RGB use 0 IRE as black; NTSC-M (US) uses a 7.5 IRE pedestal -- check your display's setup-level menu. The Jaguar DAC clamps below ~6 IRE, which is why this ladder starts at 13.", 999999, 999999, WHITE);        
                         break;
                     }
                     
@@ -271,7 +271,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "SMPTE COLOR BARS", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "This pattern can be used to approximate for NTSC levels regarding contrast, brightness and colors.^^You can toggle between 75% and 100% SMPTE color bars with A. Of Course the percentages are relative to the console output.^^You can use color filters or the blue only option in your display to confirm color balance.^^This HW lowest black is ??????.", 999999, 999999, WHITE);    
+                            updateLine(settings, mainFont, helpTextBox, "This pattern can be used to approximate for NTSC levels regarding contrast, brightness and colors.^^You can toggle between 75% and 100% SMPTE color bars with A. Of course the percentages are relative to the console output.^^You can use color filters or the blue only option in your display to confirm color balance.^^This HW lowest black is ??????.", 999999, 999999, WHITE);    
                         break;
                     }
                     
@@ -297,7 +297,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "WHITE SCREEN", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "This pattern can be changed between white, black, red, green and blue screens with the 'A' and 'B' buttons.^^A custom color mode is available by pressing 'C' when on the white screen. Use left and right to select a color channel, and up and down to addjust the color channel.", 999999, 999999, WHITE);  
+                            updateLine(settings, mainFont, helpTextBox, "This pattern can be changed between white, black, red, green and blue screens with the 'A' and 'B' buttons.^^A custom color mode is available by pressing 'C' when on the white screen. Use left and right to select a color channel, and up and down to adjust the color channel.", 999999, 999999, WHITE);  
                         break;
                     }
                     
@@ -310,7 +310,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "CHECKERBOARD", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "This pattern shows all the visible pixels in an alternating white and black grid array.^^You can toggle the pattern with button 'Up', or turn on auto-toggle each auto-toggle each frame with the 'A' button. A frame counter is also available with 'B'.", 999999, 999999, WHITE);  
+                            updateLine(settings, mainFont, helpTextBox, "This pattern shows all the visible pixels in an alternating white and black grid array.^^You can toggle the pattern with button 'Up', or turn on auto-toggle each frame with the 'A' button. A frame counter is also available with 'B'.", 999999, 999999, WHITE);  
                         break;
                     }
                     
@@ -357,7 +357,7 @@ void DrawHelp(int option){
                         case 1:
                             updateLine(settings, mainFont, helpLineTextBox[0], "HOR/VER STRIPES (2/2)", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "You can also display vertical bars by pressing 'LEFT'. That pattern will help you evaluate if the signal is not distorted horizontaly, since all lines should be one pixel wide.", 999999, 999999, WHITE);   
+                            updateLine(settings, mainFont, helpTextBox, "You can also display vertical bars by pressing 'LEFT'. That pattern will help you evaluate if the signal is not distorted horizontally, since all lines should be one pixel wide.", 999999, 999999, WHITE);   
                         break;
                     }
                     
@@ -370,7 +370,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "TIMING & REFLEX (1/2)", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "The main intention is to show a changing pattern on the screen, which can be complemented with audio. This should show to some degree any lag when processing the signal.^^As an added feature, the user can click the 'A' button when the sprite is aligned with the one on the background, and the offset in frames from the actual intersection will be shown on scree, A 1khz tone will be played for 1 frame when pressed.", 999999, 999999, WHITE);   
+                            updateLine(settings, mainFont, helpTextBox, "The main intention is to show a changing pattern on the screen, which can be complemented with audio. This should show to some degree any lag when processing the signal.^^As an added feature, the user can click the 'A' button when the sprite is aligned with the one on the background, and the offset in frames from the actual intersection will be shown on screen. A 1 kHz tone will be played for 1 frame when pressed.", 999999, 999999, WHITE);   
                             
                             updateLine(settings, mainFont, helpLineTextBox[1], "Continued...", 999999, 999999, WHITE);
                         break;
@@ -391,7 +391,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "SCROLL TEST (1/2)", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "This test shows either a horizontal 320x224 background from sonic or a vertical 256x224 background from Kiki Kaikai.^^Speed can be caried with Up & Down and scrool direction with Left. The 'A' button stops the scroll and 'B' toggles between vertical and horizontal.", 999999, 999999, WHITE);                               
+                            updateLine(settings, mainFont, helpTextBox, "This test shows either a horizontal 320x224 background from sonic or a vertical 256x224 background from Kiki Kaikai.^^Speed can be varied with Up & Down and scroll direction with Left. The 'A' button stops the scroll and 'B' toggles between vertical and horizontal.", 999999, 999999, WHITE);                               
                             
                             updateLine(settings, mainFont, helpLineTextBox[1], "Continued...", 999999, 999999, WHITE);
                         break;
@@ -412,7 +412,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "GRID SCROLL TEST", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "A grid is scrolled vertically or horizontally, which can be used to test linearity of the signal and how well the display or video processor copes with scrolling and framerate.^^'B' button can be used to toggle between horizontal and certical. while Up/Down regulates speed.^^'A' button stops the scroll and 'Left' changes direction.", 999999, 999999, WHITE); 
+                            updateLine(settings, mainFont, helpTextBox, "A grid is scrolled vertically or horizontally, which can be used to test linearity of the signal and how well the display or video processor copes with scrolling and framerate.^^'B' button can be used to toggle between horizontal and vertical, while Up/Down regulates speed.^^'A' button stops the scroll and 'Left' changes direction.", 999999, 999999, WHITE); 
                         break;
                     }
                     
@@ -425,7 +425,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "BACKLIT TEST", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "This test allows you to check how the display's backlit works when only a small array of pixels is shown.^^The user can move around the white pixel arrays with the d-pad, and change the size of the pixel array with 'A'. The 'B' button allows the user to hide the pixel array in order to alternate a fully black screen.", 999999, 999999, WHITE);  
+                            updateLine(settings, mainFont, helpTextBox, "This test allows you to check how the display's backlight works when only a small array of pixels is shown.^^The user can move around the white pixel arrays with the d-pad, and change the size of the pixel array with 'A'. The 'B' button allows the user to hide the pixel array in order to alternate a fully black screen.", 999999, 999999, WHITE);  
                         break;
                     }
                     
@@ -446,7 +446,7 @@ void DrawHelp(int option){
                         case 1:
                             updateLine(settings, mainFont, helpLineTextBox[0], "LAG TEST (2/2)", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "You can splite the video signal and feed both displays.^^The vertical bars on the sides change color each frame to help when using LCD photos.^^Press A to start/stop, B to reset and C for Black & White test.", 999999, 999999, WHITE);        
+                            updateLine(settings, mainFont, helpTextBox, "You can split the video signal and feed both displays.^^The vertical bars on the sides change color each frame to help when using LCD photos.^^Press A to start/stop, B to reset and C for Black & White test.", 999999, 999999, WHITE);        
                         break;
                     }
                     

--- a/help.c
+++ b/help.c
@@ -1,13 +1,14 @@
 #include "./help.h"
 
-/* helpStrlen() / helpStrstr()
+/* helpStrlen() / helpStrstrIndex()
  *
  * Tiny in-house substring search. The Jaguar SDK's jlibc ships strlen() but
  * not strstr(), so we roll our own naive O(n*m) scan. Only ever called
  * during help-screen redraws on user-pressed OPTION+DOWN, so the
  * worst-case ~360-char haystack search is irrelevant for performance.
- * Returns the byte index of the first occurrence of `needle` in `hay`, or
- * -1 if not found. NULL inputs are treated as not-found. */
+ * helpStrstrIndex() returns the byte index of the first occurrence of
+ * `needle` in `hay`, or -1 if not found. NULL inputs are treated as not-
+ * found. */
 static int helpStrlen(const char *s){
     int n = 0;
     while(s[n] != '\0'){ n++; }
@@ -162,7 +163,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "PLUGE (1/3)", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "NTSC levels require black to beat 7.5 IRE for video. This HW lowest is 6 IRE (6%), so using this value for general 240p use is not recommended.^^Of course using it as reference will work perfectly for games in this platform.^^In PAL - and console gaming in general - it is advised to use a value of 2 IRE as black.", 999999, 999999, WHITE);
+                            updateLine(settings, mainFont, helpTextBox, "NTSC-M levels set black at a 7.5 IRE setup pedestal for video. The Jaguar's HW analog floor is 6 IRE (6%), so using that value for general 240p use is not recommended.^^Of course using it as reference will work perfectly for games on this platform.^^In PAL - and console gaming in general - it is advised to use a value of 2 IRE as black.", 999999, 999999, WHITE);
                             
                             updateLine(settings, mainFont, helpLineTextBox[1], "Continued...", 999999, 999999, WHITE);
                         break;
@@ -267,7 +268,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "100 IRE", 999999, 999999, GREEN);
                             
-                            updateLine(settings, mainFont, helpTextBox, "You can vary IRE intensity with A and B. Values are: 13, 25, 41, 53, 66, 82, 94.^^Each step maps to (IRE/100) * 63 on the Jaguar's 6-bit green channel; red and blue are driven at half that to stay neutral.^^NTSC-J / PAL / PC RGB use 0 IRE as black; NTSC-M (US) uses a 7.5 IRE pedestal -- check your display's setup-level menu. The Jaguar DAC clamps below ~6 IRE, which is why this ladder starts at 13.", 999999, 999999, WHITE);        
+                            updateLine(settings, mainFont, helpTextBox, "You can vary IRE intensity with A and B. Values are: 13, 25, 41, 53, 66, 82, 94.^^Each step is computed as g = round((IRE/100) * 64) on the Jaguar's 6-bit green channel (0..63); red and blue (5-bit, 0..31) are driven at g >> 1 to stay neutral.^^NTSC-J / PAL / PC RGB use 0 IRE as black; NTSC-M (US) uses a 7.5 IRE setup pedestal -- check your display's setup-level menu. The Jaguar DAC clamps below ~6 IRE, which is why this ladder starts at 13.", 999999, 999999, WHITE);        
                         break;
                     }
                     

--- a/main.c
+++ b/main.c
@@ -1302,7 +1302,7 @@ void drawCredits(){
                     updateLine(settings, mainFont, lineTextBox[14], "Advisor:", settings->lineXOffset, setLineYPos(13), GREEN);
                     updateLine(settings, mainFont, lineTextBox[15], "  ()  ", settings->lineXOffset, setLineYPos(14), WHITE);
 
-                    updateLine(settings, mainFont, lineTextBox[16], "                   Ver. 0.6.4 - 04/19/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
+                    updateLine(settings, mainFont, lineTextBox[16], "                   Ver. 0.6.5 - 04/19/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
 
                     updateLine(settings, mainFont, lineTextBox[17], "Option - Return To Main Menu", settings->lineXOffset, setLineYPos(16) + 4, WHITE);
                 break;

--- a/main.c
+++ b/main.c
@@ -1299,12 +1299,14 @@ void drawCredits(){
                     updateLine(settings, mainFont, lineTextBox[11], " Jose Salot @pepe_salot", settings->lineXOffset, setLineYPos(10), WHITE);
                     updateLine(settings, mainFont, lineTextBox[12], "Menu Art:", settings->lineXOffset, setLineYPos(11), GREEN);
                     updateLine(settings, mainFont, lineTextBox[13], " Asher", settings->lineXOffset, setLineYPos(12), WHITE);
-                    updateLine(settings, mainFont, lineTextBox[14], "Advisor:", settings->lineXOffset, setLineYPos(13), GREEN);
-                    updateLine(settings, mainFont, lineTextBox[15], "  ()  ", settings->lineXOffset, setLineYPos(14), WHITE);
+                    updateLine(settings, mainFont, lineTextBox[14], "Jaguar Port Updates:", settings->lineXOffset, setLineYPos(13), GREEN);
+                    updateLine(settings, mainFont, lineTextBox[15], " Joe Mattiello @JoeMatt", settings->lineXOffset, setLineYPos(14), WHITE);
+                    updateLine(settings, mainFont, lineTextBox[16], "Advisor:", settings->lineXOffset, setLineYPos(15), GREEN);
+                    updateLine(settings, mainFont, lineTextBox[17], "  ()  ", settings->lineXOffset, setLineYPos(16), WHITE);
 
-                    updateLine(settings, mainFont, lineTextBox[16], "                   Ver. 0.6.6 - 04/19/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
+                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 0.6.6 - 04/19/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
 
-                    updateLine(settings, mainFont, lineTextBox[17], "Option - Return To Main Menu", settings->lineXOffset, setLineYPos(16) + 4, WHITE);
+                    updateLine(settings, mainFont, lineTextBox[19], "Option - Return To Main Menu", settings->lineXOffset, setLineYPos(18) + 4, WHITE);
                 break;
 
             }

--- a/main.c
+++ b/main.c
@@ -1304,7 +1304,7 @@ void drawCredits(){
                     updateLine(settings, mainFont, lineTextBox[16], "Advisor:", settings->lineXOffset, setLineYPos(15), GREEN);
                     updateLine(settings, mainFont, lineTextBox[17], "  ()  ", settings->lineXOffset, setLineYPos(16), WHITE);
 
-                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 0.6.7 - 04/19/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
+                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 0.6.8 - 04/19/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
 
                     updateLine(settings, mainFont, lineTextBox[19], "Option - Return To Main Menu", settings->lineXOffset, setLineYPos(18) + 4, WHITE);
                 break;

--- a/main.c
+++ b/main.c
@@ -1304,7 +1304,7 @@ void drawCredits(){
                     updateLine(settings, mainFont, lineTextBox[16], "Advisor:", settings->lineXOffset, setLineYPos(15), GREEN);
                     updateLine(settings, mainFont, lineTextBox[17], "  ()  ", settings->lineXOffset, setLineYPos(16), WHITE);
 
-                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 0.6.6 - 04/19/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
+                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 0.6.7 - 04/19/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
 
                     updateLine(settings, mainFont, lineTextBox[19], "Option - Return To Main Menu", settings->lineXOffset, setLineYPos(18) + 4, WHITE);
                 break;

--- a/main.c
+++ b/main.c
@@ -1302,7 +1302,7 @@ void drawCredits(){
                     updateLine(settings, mainFont, lineTextBox[14], "Advisor:", settings->lineXOffset, setLineYPos(13), GREEN);
                     updateLine(settings, mainFont, lineTextBox[15], "  ()  ", settings->lineXOffset, setLineYPos(14), WHITE);
 
-                    updateLine(settings, mainFont, lineTextBox[16], "                   Ver. 0.6.5 - 04/19/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
+                    updateLine(settings, mainFont, lineTextBox[16], "                   Ver. 0.6.6 - 04/19/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
 
                     updateLine(settings, mainFont, lineTextBox[17], "Option - Return To Main Menu", settings->lineXOffset, setLineYPos(16) + 4, WHITE);
                 break;

--- a/main.c
+++ b/main.c
@@ -1304,7 +1304,7 @@ void drawCredits(){
                     updateLine(settings, mainFont, lineTextBox[16], "Advisor:", settings->lineXOffset, setLineYPos(15), GREEN);
                     updateLine(settings, mainFont, lineTextBox[17], "  ()  ", settings->lineXOffset, setLineYPos(16), WHITE);
 
-                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 0.6.8 - 04/19/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
+                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 0.6.5 - 04/19/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
 
                     updateLine(settings, mainFont, lineTextBox[19], "Option - Return To Main Menu", settings->lineXOffset, setLineYPos(18) + 4, WHITE);
                 break;

--- a/patterns.c
+++ b/patterns.c
@@ -88,13 +88,55 @@ void DrawColorBars(){
     
 };
 
+/* ---------------------------------------------------------------------------
+ * IRE intensity table (upstream issue #3: IRE Measuring & Documenting in Code)
+ *
+ * The Jaguar TOM in RGB16 mode packs pixels as R5 B5 G6 (red/blue 0..31,
+ * green 0..63). To produce a neutral gray at a given IRE percentage we drive
+ * the green channel to (IRE/100) * 63 and balance red/blue at half that
+ * (since they only have 5 bits) so the resulting RGB16 word reads as gray on
+ * the analog output:
+ *
+ *       g = round((IRE / 100) * 63)
+ *       r = b = g >> 1                       (5-bit half of the 6-bit green)
+ *       pixel = (r << 11) | (b << 6) | g
+ *
+ * The seven-step IRE ladder below matches the canonical 240p-test-suite
+ * intensities used on every other platform (Genesis / SNES / Dreamcast):
+ *
+ *       index   IRE %   green (0..63)   r,b (0..31)   notes
+ *       -----   -----   -------------   -----------   -----
+ *         0      13          8               4        ~ HW black floor + 7
+ *         1      25         16               8        low-IRE convergence
+ *         2      41         26              13        ~ NTSC mid-gray
+ *         3      53         34              17        ~ 50% IRE pivot
+ *         4      66         42              21        upper-mid gray
+ *         5      82         52              26        bright reference
+ *         6      94         60              30        ~ peak white, no clip
+ *
+ * Notes on regional reference levels:
+ *   - NTSC-J (Japan) and PC RGB use 0 IRE as black -- the table above maps
+ *     directly onto the analog signal.
+ *   - NTSC-M (US) traditionally uses a 7.5 IRE pedestal for black, so the
+ *     "true" picture range is 7.5..100 IRE. Software can't compensate for
+ *     this at the DAC; consult your display's setup-level menu.
+ *   - PAL and most modern flat panels treat 0 IRE as black, matching the
+ *     NTSC-J / PC RGB behavior.
+ *
+ * The Jaguar's hardware analog black floor sits around 6 IRE (see HELP_PLUGE
+ * text) -- below that the DAC clamps. That is why this ladder starts at 13
+ * IRE rather than 0.
+ * --------------------------------------------------------------------------- */
 void Draw100IRE(){
     
     int i = 0;
     int selection = 6;
     int selectionOld = 5;
     int displayDelay = 45;
-    int ireValues[7] = {8, 16, 26, 34, 42, 52, 60}; //Converted from a 0-100 to a 0-64 scale
+    /* IRE -> 6-bit green channel: round((IRE/100) * 63). See block comment
+     * above for the full derivation table. Red/blue are set to (green >> 1)
+     * at the CLUT write below to keep the resulting pixel neutral gray. */
+    int ireValues[7] = {8, 16, 26, 34, 42, 52, 60};
     int redraw = 1;
     
     settings->fadeToColor = 0x0000;

--- a/patterns.c
+++ b/patterns.c
@@ -92,14 +92,21 @@ void DrawColorBars(){
  * IRE intensity table (upstream issue #3: IRE Measuring & Documenting in Code)
  *
  * The Jaguar TOM in RGB16 mode packs pixels as R5 B5 G6 (red/blue 0..31,
- * green 0..63). To produce a neutral gray at a given IRE percentage we drive
- * the green channel to (IRE/100) * 63 and balance red/blue at half that
- * (since they only have 5 bits) so the resulting RGB16 word reads as gray on
- * the analog output:
+ * green 0..63 -- i.e. 64 distinct levels per channel). To produce a neutral
+ * gray at a given IRE percentage we drive the green channel to
+ * round((IRE/100) * 64) (scaling by the 6-bit level count is the convention
+ * used here, and integer-rounds cleanly for every rung in the ladder) and
+ * balance red/blue at half the green value (since they only have 5 bits) so
+ * the resulting RGB16 word reads as gray on the analog output:
  *
- *       g = round((IRE / 100) * 63)
+ *       g = round((IRE / 100) * 64)          (clamped to 0..63 max)
  *       r = b = g >> 1                       (5-bit half of the 6-bit green)
  *       pixel = (r << 11) | (b << 6) | g
+ *
+ * Note on the *64 vs *63 choice: scaling by 64 (the level count) instead of
+ * 63 (the max value) keeps the integer math clean -- e.g. 53 IRE * 64 / 100
+ * = 33.92 -> 34, while *63 would give 33.39 -> 33. The ladder maxes at
+ * 94 IRE -> 60, so the theoretical 100 IRE -> 64 clip case never occurs.
  *
  * The seven-step IRE ladder below matches the canonical 240p-test-suite
  * intensities used on every other platform (Genesis / SNES / Dreamcast):
@@ -117,9 +124,9 @@ void DrawColorBars(){
  * Notes on regional reference levels:
  *   - NTSC-J (Japan) and PC RGB use 0 IRE as black -- the table above maps
  *     directly onto the analog signal.
- *   - NTSC-M (US) traditionally uses a 7.5 IRE pedestal for black, so the
- *     "true" picture range is 7.5..100 IRE. Software can't compensate for
- *     this at the DAC; consult your display's setup-level menu.
+ *   - NTSC-M (US) traditionally uses a 7.5 IRE setup pedestal for black, so
+ *     the "true" picture range is 7.5..100 IRE. Software can't compensate
+ *     for this at the DAC; consult your display's setup-level menu.
  *   - PAL and most modern flat panels treat 0 IRE as black, matching the
  *     NTSC-J / PC RGB behavior.
  *
@@ -133,9 +140,10 @@ void Draw100IRE(){
     int selection = 6;
     int selectionOld = 5;
     int displayDelay = 45;
-    /* IRE -> 6-bit green channel: round((IRE/100) * 63). See block comment
-     * above for the full derivation table. Red/blue are set to (green >> 1)
-     * at the CLUT write below to keep the resulting pixel neutral gray. */
+    /* IRE -> 6-bit green channel: round((IRE/100) * 64). See block comment
+     * above for the full derivation table and the rationale for *64 over
+     * *63. Red/blue are set to (green >> 1) at the CLUT write below to
+     * keep the resulting pixel neutral gray. */
     int ireValues[7] = {8, 16, 26, 34, 42, 52, 60};
     int redraw = 1;
     


### PR DESCRIPTION
## Summary

A small post-v0.6.4 cleanup PR that knocks out two upstream BitJag issues and clears the Node-20 deprecation banner from the release workflow.

### Closes upstream issue [#13 — Typos in Checkerboard help screen and Backlight Test](https://github.com/BitJag/atari_jaguar_240p_test_suite/issues/13)

While verifying the upstream-flagged typos in the Checkerboard and Backlight help screens, I greped every help-string in `help.c` and found 13 to fix in total:

| Was | Now |
| --- | --- |
| `Evalute 240p signals` | `Evaluate 240p signals` |
| `video procesors` | `video processors` |
| `it is advized` | `it is advised` |
| `corner purity and geomentry` | `corner purity and geometry` |
| `certical bars and checkerboard` (HELP_BLEED) | `vertical bars and checkerboard` |
| `Of Course the percentages` | `Of course the percentages` |
| `up and down to addjust` | `up and down to adjust` |
| `auto-toggle each auto-toggle each frame` (HELP_CHECK) | `auto-toggle each frame` |
| `shown on scree, A 1khz tone` | `shown on screen. A 1 kHz tone` |
| `Speed can be caried` | `Speed can be varied` |
| `scrool direction` | `scroll direction` |
| `horizontal and certical. while` | `horizontal and vertical, while` |
| `the display's backlit works` (HELP_LED) | `the display's backlight works` |
| `splite the video signal` | `split the video signal` |
| `distorted horizontaly` | `distorted horizontally` |

### Addresses upstream issue [#3 — IRE Measuring & Documenting in Code](https://github.com/BitJag/atari_jaguar_240p_test_suite/issues/3)

- `patterns.c`: a full block comment above `Draw100IRE` derives the IRE-to-RGB16 mapping (`g = round(IRE/100 * 63)`, `r = b = g >> 1`) and includes:
  - Per-step table for all 7 ladder rungs (13/25/41/53/66/82/94 IRE) showing the green-channel and red/blue-channel values.
  - Regional reference notes (NTSC-J / PAL / PC RGB at 0 IRE black vs NTSC-M's 7.5 IRE pedestal).
  - Why the ladder starts at 13 IRE (the Jaguar's hardware analog black floor sits around 6 IRE — below that the DAC clamps).
- `help.c` `HELP_IRE`: extended the on-screen help text with the same formula and the regional pedestal note, so the info is reachable in the running ROM without source.

### CI: clear Node-20 deprecation banner

The `v0.6.4` release run flagged Node-20 deprecation on every JS action. All targets now confirmed Node-24-capable on GitHub:

| Action | Was | Now |
| --- | --- | --- |
| `actions/checkout` | v4 | v5 |
| `actions/upload-artifact` | v4 | v6 |
| `actions/download-artifact` | v4 | v7 |
| `docker/login-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |
| `softprops/action-gh-release` | v2 | v3 |

## Test plan

- [x] `make docker-build` produces `.bin/.cof/.rom/.j64` cleanly, ROM still 1,048,576 bytes
- [x] `grep` confirms zero remaining typos from the audit
- [x] `Draw100IRE` block comment compiles, no warnings introduced
- [ ] Smoke test in BigPEmu: open Help on Checkerboard / Backlight / 100 IRE entries and verify the corrected text reads correctly
- [ ] Verify `build.yml` workflow runs green on this PR (no Node-20 banner)
- [ ] Verify next release tag triggers `release.yml` cleanly with the new action versions

Made with [Cursor](https://cursor.com)