### PR TITLE
CI: add libretro boot smoke test (`make test` + GHA job)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,13 @@ jobs:
     # there's no host runtime, so the only meaningful "did it work?"
     # signal comes from running the ROM in an emulator.
     needs: build
+    # The smoke test consumes the *release* artifact, so skip when the
+    # release flavour was filtered out of the build matrix (workflow_dispatch
+    # with flavours=debug). Default branch/PR runs always build both.
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.flavours == 'both' ||
+      github.event.inputs.flavours == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -150,7 +157,15 @@ jobs:
           ref: ${{ env.VJ_CORE_REF }}
           path: vj-core
 
-      # Cache the built core keyed on the VJ source tree's commit SHA so
+      # Capture the actual checked-out commit SHA -- relying on .git/HEAD
+      # via hashFiles() is brittle (the file can be a symbolic ref like
+      # `ref: refs/heads/master`, whose contents don't change as upstream
+      # advances, leaving the cache permanently warm against a stale core).
+      - name: Resolve vj-core SHA
+        id: vj-sha
+        run: echo "sha=$(git -C vj-core rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Cache the built core keyed on the resolved upstream SHA so
       # subsequent CI runs (with the same upstream HEAD) skip the ~90s
       # rebuild. Cache miss = build from scratch and populate the cache.
       - name: Cache built libretro core
@@ -158,7 +173,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: vj-core/virtualjaguar_libretro.so
-          key: vj-core-${{ runner.os }}-${{ hashFiles('vj-core/.git/HEAD') }}
+          key: vj-core-${{ runner.os }}-${{ steps.vj-sha.outputs.sha }}
 
       - name: Build virtualjaguar_libretro.so
         if: steps.core-cache.outputs.cache-hit != 'true'
@@ -193,12 +208,12 @@ jobs:
           .venv/bin/pip install --upgrade pip
           .venv/bin/pip install 'libretro.py[cli]' Pillow
 
-      - name: Boot ROM (60 frames + dump init framebuffer)
+      - name: Boot ROM (60 frames + dump final framebuffer)
         # What this proves:
         #   - load_game returned True (ROM header / size / format accepted)
         #   - 60 retro_run() calls execute without raising or _exit()
         #
-        # What this does NOT prove (intentional):
+        # What it does NOT prove (intentional):
         #   - that the cart's menu is visually correct. The Jaguar BIOS
         #     animation requires a real Atari BIOS ROM (copyrighted, not
         #     redistributable) to advance to cart code. Without a BIOS,
@@ -206,19 +221,22 @@ jobs:
         #     state for the entire run -- every captured frame is bit-
         #     identical regardless of frame count.
         #
-        # The single dumped frame (frame-0000.png) is therefore the boot
-        # framebuffer, useful as a smoke artifact but not as a render
-        # regression check. If the BIOS-init pixels ever change shape
-        # something fundamental broke (linker layout, fastboot signature,
-        # video init); otherwise the meaningful signal is in the log.
+        # Param math: --frames 60 produces indices 0..59. --dump-every 59
+        # therefore matches at i=0 and i=59, dumping frame-0000.png AND
+        # frame-0059.png. We delete the boot frame so the uploaded artifact
+        # is unambiguously the *last* rendered frame -- if a BIOS ever
+        # lands in CI, that PNG will be the menu, not the splash. Today
+        # both PNGs are identical due to the BIOS gate documented above,
+        # but the param/intent now reads correctly at face value.
         run: |
           mkdir -p smoke-out
           .venv/bin/python rom/scripts/libretro-load-test.py \
             --frames 60 \
-            --dump-frames smoke-out --dump-every 60 \
+            --dump-frames smoke-out --dump-every 59 \
             --summary \
             vj-core/virtualjaguar_libretro.so \
             rom-artifact/${PROJECT}.jag
+          rm -f smoke-out/frame-0000.png
 
       - name: Upload smoke screenshot
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,105 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  smoke-test:
+    name: Smoke test (libretro boot)
+    # Boots the built ROM in a Linux libretro core for a few dozen frames
+    # to catch init / main() regressions before they ship. This is the
+    # closest thing this bare-metal codebase can have to a unit test --
+    # there's no host runtime, so the only meaningful "did it work?"
+    # signal comes from running the ROM in an emulator.
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      PROJECT: jag_240p_test_suite
+      # Pin to upstream master. To test against a fork or pinned SHA,
+      # override here -- for example:
+      #   VJ_CORE_REPO: Provenance-Emu/virtualjaguar-libretro
+      #   VJ_CORE_REF:  some-feature-branch
+      VJ_CORE_REPO: libretro/virtualjaguar-libretro
+      VJ_CORE_REF: master
+    steps:
+      - name: Checkout ROM repo
+        uses: actions/checkout@v5
+        with:
+          path: rom
+
+      - name: Checkout virtualjaguar-libretro
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ env.VJ_CORE_REPO }}
+          ref: ${{ env.VJ_CORE_REF }}
+          path: vj-core
+
+      # Cache the built core keyed on the VJ source tree's commit SHA so
+      # subsequent CI runs (with the same upstream HEAD) skip the ~90s
+      # rebuild. Cache miss = build from scratch and populate the cache.
+      - name: Cache built libretro core
+        id: core-cache
+        uses: actions/cache@v4
+        with:
+          path: vj-core/virtualjaguar_libretro.so
+          key: vj-core-${{ runner.os }}-${{ hashFiles('vj-core/.git/HEAD') }}
+
+      - name: Build virtualjaguar_libretro.so
+        if: steps.core-cache.outputs.cache-hit != 'true'
+        run: make -j$(nproc) -C vj-core
+
+      - name: Compute release artifact name
+        id: artifact
+        run: |
+          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          echo "name=${PROJECT}-release-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Download release ROM artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          path: rom-artifact
+
+      - name: Prepare libretro content (.cof -> .jag)
+        # The Virtual Jaguar libretro core's content-type filter accepts
+        # .jag/.j64. The .j64 is a $802000-mapped cart image which the
+        # core can't currently boot via libretro (signature/header path
+        # is bypassed); the .cof renamed to .jag is the dev-test content
+        # that actually loads. The shipping .j64 is still verified
+        # byte-perfect by the verify-sig step in the build job.
+        run: |
+          ls -lh rom-artifact/
+          cp "rom-artifact/${PROJECT}.cof" "rom-artifact/${PROJECT}.jag"
+
+      - name: Set up Python venv with libretro.py
+        run: |
+          python3 -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install 'libretro.py[cli]' Pillow
+
+      - name: Boot ROM (60 frames + dump final frame)
+        # --frames 60 gives ~1s of menu activity (NTSC). --dump-every 60
+        # captures only the final frame as PNG so we get a single visual
+        # artifact per CI run instead of a 60-image dump.
+        # --summary prints per-frame pixel-format / non-black ratio so
+        # the CI log shows whether the menu actually drew pixels.
+        run: |
+          mkdir -p smoke-out
+          .venv/bin/python rom/scripts/libretro-load-test.py \
+            --frames 60 \
+            --dump-frames smoke-out --dump-every 60 \
+            --summary \
+            vj-core/virtualjaguar_libretro.so \
+            rom-artifact/${PROJECT}.jag
+
+      - name: Upload smoke screenshot
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: smoke-test-frame-${{ github.sha }}
+          path: smoke-out/
+          retention-days: 14
+          if-no-files-found: warn
+
   pr-comment:
     name: Post PR build summary
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
       # rebuild. Cache miss = build from scratch and populate the cache.
       - name: Cache built libretro core
         id: core-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vj-core/virtualjaguar_libretro.so
           key: vj-core-${{ runner.os }}-${{ hashFiles('vj-core/.git/HEAD') }}
@@ -193,17 +193,19 @@ jobs:
           .venv/bin/pip install --upgrade pip
           .venv/bin/pip install 'libretro.py[cli]' Pillow
 
-      - name: Boot ROM (60 frames + dump final frame)
-        # --frames 60 gives ~1s of menu activity (NTSC). --dump-every 60
-        # captures only the final frame as PNG so we get a single visual
-        # artifact per CI run instead of a 60-image dump.
+      - name: Boot ROM (90 frames + dump 3 checkpoints)
+        # --frames 90 gives ~1.5s of menu activity (NTSC). --dump-every 30
+        # captures frames 0 / 30 / 60 -- the first is BIOS init (mostly
+        # black with the cyan top stripe), the latter two should show the
+        # menu fully drawn. Three checkpoints is a useful evolution view
+        # for ~0.5s of extra runtime over a single capture.
         # --summary prints per-frame pixel-format / non-black ratio so
         # the CI log shows whether the menu actually drew pixels.
         run: |
           mkdir -p smoke-out
           .venv/bin/python rom/scripts/libretro-load-test.py \
-            --frames 60 \
-            --dump-frames smoke-out --dump-every 60 \
+            --frames 90 \
+            --dump-frames smoke-out --dump-every 30 \
             --summary \
             vj-core/virtualjaguar_libretro.so \
             rom-artifact/${PROJECT}.jag
@@ -232,7 +234,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Sticky comment with download links
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         # Belt-and-braces: even within the same repo, never let a comment
         # failure block the merge -- the artifacts upload is the source of truth.
         continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,19 +193,21 @@ jobs:
           .venv/bin/pip install --upgrade pip
           .venv/bin/pip install 'libretro.py[cli]' Pillow
 
-      - name: Boot ROM (90 frames + dump 3 checkpoints)
-        # --frames 90 gives ~1.5s of menu activity (NTSC). --dump-every 30
-        # captures frames 0 / 30 / 60 -- the first is BIOS init (mostly
-        # black with the cyan top stripe), the latter two should show the
-        # menu fully drawn. Three checkpoints is a useful evolution view
-        # for ~0.5s of extra runtime over a single capture.
+      - name: Boot ROM (400 frames + dump 4 checkpoints)
+        # The Jaguar BIOS animation runs ~5s before yielding to cart code,
+        # so anything < 300 frames at 60fps just captures the BIOS splash
+        # (every frame ~1.2% non-black, only the cyan top stripe drawn).
+        # --frames 400 gives ~6.6s of runtime which lands well past BIOS
+        # entry into the cart's main menu. --dump-every 100 captures
+        # frames 0 / 100 / 200 / 300 -- a clear evolution view from BIOS
+        # init through menu render for ~6s of CI wall-clock.
         # --summary prints per-frame pixel-format / non-black ratio so
-        # the CI log shows whether the menu actually drew pixels.
+        # the CI log shows the moment the menu actually starts drawing.
         run: |
           mkdir -p smoke-out
           .venv/bin/python rom/scripts/libretro-load-test.py \
-            --frames 90 \
-            --dump-frames smoke-out --dump-every 30 \
+            --frames 400 \
+            --dump-frames smoke-out --dump-every 100 \
             --summary \
             vj-core/virtualjaguar_libretro.so \
             rom-artifact/${PROJECT}.jag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,21 +193,29 @@ jobs:
           .venv/bin/pip install --upgrade pip
           .venv/bin/pip install 'libretro.py[cli]' Pillow
 
-      - name: Boot ROM (400 frames + dump 4 checkpoints)
-        # The Jaguar BIOS animation runs ~5s before yielding to cart code,
-        # so anything < 300 frames at 60fps just captures the BIOS splash
-        # (every frame ~1.2% non-black, only the cyan top stripe drawn).
-        # --frames 400 gives ~6.6s of runtime which lands well past BIOS
-        # entry into the cart's main menu. --dump-every 100 captures
-        # frames 0 / 100 / 200 / 300 -- a clear evolution view from BIOS
-        # init through menu render for ~6s of CI wall-clock.
-        # --summary prints per-frame pixel-format / non-black ratio so
-        # the CI log shows the moment the menu actually starts drawing.
+      - name: Boot ROM (60 frames + dump init framebuffer)
+        # What this proves:
+        #   - load_game returned True (ROM header / size / format accepted)
+        #   - 60 retro_run() calls execute without raising or _exit()
+        #
+        # What this does NOT prove (intentional):
+        #   - that the cart's menu is visually correct. The Jaguar BIOS
+        #     animation requires a real Atari BIOS ROM (copyrighted, not
+        #     redistributable) to advance to cart code. Without a BIOS,
+        #     the libretro framebuffer stays at the cyan-stripe init
+        #     state for the entire run -- every captured frame is bit-
+        #     identical regardless of frame count.
+        #
+        # The single dumped frame (frame-0000.png) is therefore the boot
+        # framebuffer, useful as a smoke artifact but not as a render
+        # regression check. If the BIOS-init pixels ever change shape
+        # something fundamental broke (linker layout, fastboot signature,
+        # video init); otherwise the meaningful signal is in the log.
         run: |
           mkdir -p smoke-out
           .venv/bin/python rom/scripts/libretro-load-test.py \
-            --frames 400 \
-            --dump-frames smoke-out --dump-every 100 \
+            --frames 60 \
+            --dump-frames smoke-out --dump-every 60 \
             --summary \
             vj-core/virtualjaguar_libretro.so \
             rom-artifact/${PROJECT}.jag

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ include Makefile.docker
         docker-up colima-start colima-stop colima-status \
         ensure-build ensure-j64 fresh-build fresh-j64 run run-ui run-headless \
         libretro-venv libretro-test libretro-run libretro-frames \
-        unquarantine-core verify-sig \
+        unquarantine-core verify-sig test test-core test-deps \
         in-docker native-build help help-toolchain
 
 # ---------------------------------------------------------------------------

--- a/Makefile.config
+++ b/Makefile.config
@@ -34,3 +34,18 @@ CFLAGS		= -mc68000 -Wall -fomit-frame-pointer -O2 -msoft-float -funroll-loops -D
 MACFLAGS	= -fb -v
 BUILD_SUFFIX	=
 endif
+
+# ---------------------------------------------------------------------------
+# Smoke-test tunables (consumed by the test/test-core/test-deps targets in
+# Makefile.docker, which keeps the libretro/Docker plumbing alongside the
+# rest of the libretro-* family).
+#
+#   TEST_FRAMES  -- how many retro_run() calls `make test` issues against
+#                   the loaded ROM. 60 is ~1s NTSC; bump it if you're
+#                   hunting for sustained-run regressions.
+#   VJ_CORE_SRC  -- where to find a virtualjaguar-libretro source checkout
+#                   for `make test-core` to build. Defaults to a sibling
+#                   directory because that's where most folks clone it.
+# ---------------------------------------------------------------------------
+TEST_FRAMES	?= 60
+VJ_CORE_SRC	?= ../virtualjaguar-libretro

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -113,7 +113,7 @@ DOCKER_RUN_TTY	= $(DOCKER) run --rm -it --init \
         docker-up colima-start colima-stop colima-status \
         ensure-j64 run run-ui run-headless \
         libretro-venv libretro-test libretro-run libretro-frames \
-        verify-sig
+        verify-sig test test-core test-deps
 
 # ---------------------------------------------------------------------------
 # docker-up: order-only prereq for every target that touches the docker CLI.
@@ -481,6 +481,72 @@ libretro-frames: ensure-j64 libretro-venv
 verify-sig:
 	python3 scripts/verify-sig.py
 
+# ---------------------------------------------------------------------------
+# Smoke test targets.
+#
+# This project is a bare-metal Jaguar ROM with no host runtime, so there
+# are no traditional unit tests -- the "tests" are the on-screen patterns
+# the ROM itself draws. What we *can* meaningfully automate is a boot
+# smoke test: load the built ROM into a Jaguar libretro core, run a few
+# dozen frames, assert nothing crashes. That catches main() / init
+# regressions before they ship, which covers the lion's share of what a
+# unit suite would catch in a host-side codebase.
+#
+#   make test         -- verify-sig + libretro boot (default 60 frames)
+#   make test-core    -- build virtualjaguar_libretro.{so,dylib,dll} from
+#                        a sibling checkout of libretro/virtualjaguar-libretro
+#                        and copy it next to the Makefile
+#   make test-deps    -- print resolved test-related variables for debug
+#
+# Tunable:
+#   TEST_FRAMES=N     -- frames to run after load (default 60). 0 = load only
+#   VJ_CORE_SRC=DIR   -- where to find the VJ libretro source for `test-core`
+#                        (default ../virtualjaguar-libretro)
+#
+# CI runs the same flow on every push (see .github/workflows/build.yml
+# `smoke-test` job), so what passes locally passes in CI.
+# ---------------------------------------------------------------------------
+TEST_FRAMES	?= 60
+VJ_CORE_SRC	?= ../virtualjaguar-libretro
+
+test: verify-sig
+	@printf '>> Booting ROM in libretro core for %s frame(s)...\n' "$(TEST_FRAMES)"
+	@$(MAKE) --no-print-directory LIBRETRO_FRAMES=$(TEST_FRAMES) libretro-test
+
+# Build the Linux/macOS libretro core from a sibling checkout. We
+# deliberately do NOT auto-clone -- if the user wants a specific fork or
+# branch (Provenance-Emu/virtualjaguar-libretro, a feature branch, a
+# pinned rev), they should set that up manually.
+test-core:
+	@if [ ! -d "$(VJ_CORE_SRC)" ]; then \
+		printf '!! virtualjaguar-libretro source not found at %s\n' "$(VJ_CORE_SRC)" >&2; \
+		printf '   Clone it as a sibling of this repo:\n' >&2; \
+		printf '     git clone https://github.com/libretro/virtualjaguar-libretro %s\n' "$(VJ_CORE_SRC)" >&2; \
+		printf '   Or point at an existing checkout:\n' >&2; \
+		printf '     make test-core VJ_CORE_SRC=/path/to/virtualjaguar-libretro\n' >&2; \
+		exit 1; \
+	fi
+	$(MAKE) -j$$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4) -C "$(VJ_CORE_SRC)"
+	@_ext=so; \
+	case "$$(uname)" in \
+		Darwin) _ext=dylib ;; \
+		Linux)  _ext=so ;; \
+		MINGW*|CYGWIN*|MSYS*) _ext=dll ;; \
+	esac; \
+	if [ ! -f "$(VJ_CORE_SRC)/virtualjaguar_libretro.$$_ext" ]; then \
+		printf '!! Build succeeded but %s/virtualjaguar_libretro.%s is missing.\n' "$(VJ_CORE_SRC)" "$$_ext" >&2; \
+		exit 1; \
+	fi; \
+	cp -f "$(VJ_CORE_SRC)/virtualjaguar_libretro.$$_ext" "./virtualjaguar_libretro.$$_ext"; \
+	printf '>> Core ready: ./virtualjaguar_libretro.%s. Run `make test`.\n' "$$_ext"
+
+test-deps:
+	@printf 'TEST_FRAMES      = %s\n'   "$(TEST_FRAMES)"
+	@printf 'VJ_CORE_SRC      = %s (%s)\n' "$(VJ_CORE_SRC)" "$(if $(wildcard $(VJ_CORE_SRC)),exists,not found)"
+	@printf 'LIBRETRO_CORE    = %s\n'   "$(LIBRETRO_CORE)"
+	@printf 'LIBRETRO_CONTENT = %s\n'   "$(LIBRETRO_CONTENT)"
+	@printf 'LIBRETRO_PYTHON  = %s\n'   "$(LIBRETRO_PYTHON)"
+
 sdk-pull: | docker-up
 	$(DOCKER) pull $(SDK_IMAGE)
 
@@ -578,6 +644,12 @@ help:
 	@printf '  %-22s %s\n' 'libretro-run'     'libretro-test + run 0 frames (load-only smoke-test, see comment in target)'
 	@printf '  %-22s %s\n' 'libretro-frames'  'render 180 frames and dump every 30th to ./frames/*.png'
 	@printf '  %-22s %s\n' 'verify-sig'       'check fastboot signature matches tursilion/makefastboot'
+	@printf '\n'
+	@printf 'Smoke tests (this codebase has no host-runnable unit tests by design;\n'
+	@printf 'the "tests" are visual patterns drawn by the ROM itself):\n'
+	@printf '  %-22s %s\n' 'test'             'verify-sig + boot in libretro core for $$(TEST_FRAMES) frames (default 60)'
+	@printf '  %-22s %s\n' 'test-core'        'build virtualjaguar_libretro.* from $$(VJ_CORE_SRC) (default ../virtualjaguar-libretro)'
+	@printf '  %-22s %s\n' 'test-deps'        'print resolved test variables (debug)'
 	@printf '  %-22s %s\n' 'bjl'              'send .bin via BJL (lo -8)'
 	@printf '  %-22s %s\n' 'alpine / debug'   'launch under Alpine debugger / WDB'
 	@printf '\n'

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -506,8 +506,9 @@ verify-sig:
 # CI runs the same flow on every push (see .github/workflows/build.yml
 # `smoke-test` job), so what passes locally passes in CI.
 # ---------------------------------------------------------------------------
-TEST_FRAMES	?= 60
-VJ_CORE_SRC	?= ../virtualjaguar-libretro
+# TEST_FRAMES and VJ_CORE_SRC live in Makefile.config (alongside DEBUG and
+# the other host-tunable knobs); the rules below stay here so they sit
+# next to verify-sig / libretro-test / libretro-run, which they delegate to.
 
 test: verify-sig
 	@printf '>> Booting ROM in libretro core for %s frame(s)...\n' "$(TEST_FRAMES)"

--- a/README.md
+++ b/README.md
@@ -127,7 +127,10 @@ The lower-level targets are still available for finer control:
 ```bash
 make run                  # build .j64 and do a deterministic headless smoke run
 make run-ui               # attempt UI launch (RetroArch; may crash on broken setups)
-make libretro-run         # build .j64, init core, run 0 frames (load-only)
+make libretro-run         # build, init core, load_game on $(OUT_PROJECT).jag (the .cof renamed),
+                          # run 0 frames -- proves the core's content filter accepts the cart.
+                          # Override with LIBRETRO_CONTENT=$(OUT_PROJECT).j64 to test the cart-image
+                          # path instead (currently fails to boot without a real BIOS, see notes below).
 make libretro-test        # init core + load_game (use LIBRETRO_FRAMES=N for frames)
 make libretro-frames      # render 180 frames and dump every 30th to ./frames/*.png
 ```

--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ make libretro-frames      # render 180 frames and dump every 30th to ./frames/*.
 
 The first invocation auto-creates `.venv-libretro/` and `pip install`s [JesseTG/libretro.py](https://github.com/JesseTG/libretro.py) into it; subsequent runs reuse it. The core is not committed to the repo (it's in `.gitignore`); grab the build that matches your platform from the [virtualjaguar_libretro releases](https://github.com/libretro/virtualjaguar-libretro) or RetroArch's online updater.
 
+**What the smoke test actually proves**
+
+- `load_game` returned `True` (the libretro core accepted the ROM header / size / extension filter).
+- N `retro_run()` calls execute without raising or `_exit()`-ing.
+
+**What it does NOT prove (intentional)**
+
+- That the cart's menu is *visually* correct on a real Jaguar. The Virtual Jaguar BIOS animation requires a real Atari Jaguar BIOS ROM (copyrighted, not redistributable) to advance into cart code. Without a BIOS, the libretro framebuffer stays at the cyan-stripe init state for the entire run -- every captured frame is bit-identical regardless of frame count. The CI screenshot artifact (`smoke-test-frame-<sha>/frame-0000.png`) is therefore the *boot framebuffer*, not a render-regression baseline. If those init pixels ever change shape something fundamental broke (linker layout, fastboot signature, video init); otherwise the meaningful signal is in the log, not the image.
+
 > **macOS caveat:** the Virtual Jaguar libretro core has an upstream bug where it calls `_exit(0)` from inside the first `retro_run()` invocation on macOS. The `libretro-load-test.py` harness treats `load_game returned True` in the log as success regardless of subsequent crashes, so `make test` still gives a meaningful signal — but the process exit code may misreport. CI runs on Linux where the bug doesn't apply.
 
 If you'd rather wrap the `.bin` with a different tool, the original sources of the same fastboot algorithm are:

--- a/README.md
+++ b/README.md
@@ -106,16 +106,35 @@ ROM output is padded with trailing `0xFF` to the next 1 MiB boundary. This is re
 
 #### Smoke-testing against a libretro core
 
-If you want to verify a build actually loads (and runs) before pushing to a real device, drop your libretro core (e.g. `virtualjaguar_libretro.dylib`) into the repo root and run:
+This codebase has no host-runnable unit tests by design — it's bare-metal Jaguar M68K with hardware register pokes, and the "tests" the project provides are the on-screen patterns the ROM itself draws. What we *can* automate is a boot smoke test: load the built ROM into a Jaguar libretro core and assert it runs N frames without crashing.
+
+```bash
+make test                 # verify-sig + boot in libretro core for 60 frames (default)
+make test TEST_FRAMES=300 # tweak frame count
+make test-core            # build virtualjaguar_libretro.* from ../virtualjaguar-libretro
+make test-deps            # show resolved test variables (debug)
+```
+
+`make test` is the recommended one-command "did I break boot?" check. It runs the fastboot-signature regression test (`scripts/verify-sig.py`) and then boots the ROM in your local libretro core. CI runs the same flow on every push (see `.github/workflows/build.yml` `smoke-test` job, which builds the core from `libretro/virtualjaguar-libretro@master` and uploads the final-frame screenshot as a downloadable artifact).
+
+If you don't have a libretro core handy:
+
+- Run `make test-core` to build one from a sibling checkout of `libretro/virtualjaguar-libretro` (clone it as `../virtualjaguar-libretro` first, or override `VJ_CORE_SRC=/path/to/checkout`).
+- Or drop a prebuilt `virtualjaguar_libretro.{dylib,so,dll}` next to the Makefile manually.
+
+The lower-level targets are still available for finer control:
 
 ```bash
 make run                  # build .j64 and do a deterministic headless smoke run
 make run-ui               # attempt UI launch (RetroArch; may crash on broken setups)
-make libretro-run         # build .j64, init core, run 60 frames
-make libretro-test        # init core + load_game only (faster)
+make libretro-run         # build .j64, init core, run 0 frames (load-only)
+make libretro-test        # init core + load_game (use LIBRETRO_FRAMES=N for frames)
+make libretro-frames      # render 180 frames and dump every 30th to ./frames/*.png
 ```
 
 The first invocation auto-creates `.venv-libretro/` and `pip install`s [JesseTG/libretro.py](https://github.com/JesseTG/libretro.py) into it; subsequent runs reuse it. The core is not committed to the repo (it's in `.gitignore`); grab the build that matches your platform from the [virtualjaguar_libretro releases](https://github.com/libretro/virtualjaguar-libretro) or RetroArch's online updater.
+
+> **macOS caveat:** the Virtual Jaguar libretro core has an upstream bug where it calls `_exit(0)` from inside the first `retro_run()` invocation on macOS. The `libretro-load-test.py` harness treats `load_game returned True` in the log as success regardless of subsequent crashes, so `make test` still gives a meaningful signal — but the process exit code may misreport. CI runs on Linux where the bug doesn't apply.
 
 If you'd rather wrap the `.bin` with a different tool, the original sources of the same fastboot algorithm are:
 

--- a/scripts/libretro-load-test.py
+++ b/scripts/libretro-load-test.py
@@ -103,7 +103,10 @@ def main(argv: list[str]) -> int:
     # NOT flush -- they only run on synchronous errors and Python exits
     # cleanly after them. Anything printed AFTER session.run() may not
     # appear if the core takes that exit path even with flush=True.
-    if args.frames > 0:
+    ## The Virtual Jaguar libretro core calls raw _exit(0) from inside the
+    ## first retro_run() invocation on macOS only -- gate the warning so it
+    ## doesn't pollute Linux/Windows CI logs (where the core runs cleanly).
+    if args.frames > 0 and sys.platform == "darwin":
         print(
             ">> NOTE: requesting >0 frames against virtualjaguar on macOS will\n"
             "         likely cause the core to call _exit(0) from inside\n"


### PR DESCRIPTION
## Summary
This codebase has no host-runnable unit tests by design — it's bare-metal Jaguar M68K, the "tests" are the on-screen patterns the ROM draws. What we *can* automate is a boot smoke test: load the ROM into a libretro core, run a few dozen frames, assert nothing crashes. That covers the bulk of what unit tests would catch in a host-side codebase (init / main() regressions).

- **`make test`** — verify-sig + 60-frame libretro boot. Recommended one-command "did I break boot?" check.
- **`make test-core`** — build `virtualjaguar_libretro.{so,dylib,dll}` from a sibling checkout of `libretro/virtualjaguar-libretro`.
- **`make test-deps`** — print resolved test variables for debug.
- **New CI job** `smoke-test` in `build.yml` — depends on `build`, builds the core from `libretro/virtualjaguar-libretro@master` (cached on upstream HEAD SHA), boots the ROM 60 frames, uploads the boot framebuffer as a downloadable artifact.

## Tunable
| Var | Default | Purpose |
| --- | --- | --- |
| `TEST_FRAMES` | `60` | Frames after load (`0` = load only) |
| `VJ_CORE_SRC` | `../virtualjaguar-libretro` | Source for `make test-core` |
| `VJ_CORE_REPO` (CI) | `libretro/virtualjaguar-libretro` | Override to point at a fork |
| `VJ_CORE_REF` (CI) | `master` | Override to pin a specific SHA / branch |

## What this proves vs doesn't (important — see commit `bf78ad9`)

**Proves**
- `load_game` returned `True` (header / size / extension filter passed)
- 60 `retro_run()` calls execute without raising or `_exit()`-ing

**Does NOT prove**
- That the menu *renders* correctly. The Virtual Jaguar libretro core needs a real Atari Jaguar BIOS ROM (copyrighted, not redistributable in CI) to advance the M68K through the BIOS animation into cart code. Without a BIOS the libretro framebuffer stays at the cyan-stripe init state for the entire run — frame 60 == frame 600 == frame 6000 visually. We confirmed this empirically by running 400 frames and getting bit-identical screenshots throughout.

The `smoke-test-frame-<sha>` artifact is therefore the **boot framebuffer**, not a render-regression baseline. If those init pixels ever change shape it indicates a fundamental break (linker layout, fastboot signature, video init); otherwise the meaningful CI signal is `load_game returned True` in the smoke-test job log.

## Followups landed in this PR
- `actions/cache@v4` → `@v5` (Node 24, clears deprecation warning)
- `marocchino/sticky-pull-request-comment@v2` → `@v3` (Node 24, clears deprecation warning)
- `libretro-load-test.py`: gate the macOS `_exit(0)` warning on `sys.platform == 'darwin'` so it stops printing on Linux runs

## Test plan
- [ ] Locally: clone `libretro/virtualjaguar-libretro` as `../virtualjaguar-libretro`.
- [ ] `make test-core` — should build the core and copy `virtualjaguar_libretro.dylib` next to the Makefile.
- [ ] `make test` — should run `verify-sig.py` then boot the ROM 60 frames. macOS may misreport exit code (upstream core bug); look for `load_game returned True` in the output as the actual success signal.
- [ ] `make test-deps` — should show resolved paths.
- [ ] `make help` — should list `test`, `test-core`, `test-deps` under a "Smoke tests" section.
- [x] Push this PR; CI should grow a third job `Smoke test (libretro boot)` after the two build jobs. ✅ runs in ~19s on cache hit, ~37s on cache miss.
- [x] Download the `smoke-test-frame-<sha>` artifact and confirm it's the boot framebuffer (cyan top stripe, otherwise black).

## Why this approach over alternatives
- **Traditional unit tests**: fundamentally not possible without rewriting the SDK with host stubs. No `assert()`, no stdout, all output is visual or hardware-poked. Cost-benefit doesn't pencil.
- **Buildbot core**: too old, won't boot the latest ROMs (per @JoeMatt).
- **`Provenance-Emu/virtualjaguar-libretro` artifact**: adds a cross-repo download dep + needs their CI green to run. Source-build from upstream is more reliable and the user has been merging fixes upstream anyway.