### PR TITLE
feat: Y/C delay, diagonal, vertical scroll patterns + Backlit→Backlight typo (BitJag #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Tests are grouped into five top-level menus. Items in **bold** were added or sub
 
 | Menu | Tests |
 | --- | --- |
-| **Test Patterns** | Pluge · Color Bars · EBU Color Bars · SMPTE Color Bars · Referenced Color Bars · Color Bleed Check · Monoscope · Grid · Gray Ramp · White & RGB Screens · 100 IRE · Sharpness · Overscan · Convergence · **More Patterns →** (**Color Bars w/ Gray** · **Linearity** · **Phase** · **Brightness** · **Contrast**) |
-| **Video Tests** | Drop Shadow · **Striped Sprite** · Lag Test · **Manual Lag Test** · Timing & Reflex · Scroll · Grid Scroll · Horiz/Vert Stripes · Checkerboard · Backlit Zone · **Alternate 240p/480i** |
+| **Test Patterns** | Pluge · Color Bars · EBU Color Bars · SMPTE Color Bars · Referenced Color Bars · Color Bleed Check · Monoscope · Grid · Gray Ramp · White & RGB Screens · 100 IRE · Sharpness · Overscan · Convergence · **More Patterns →** (**Color Bars w/ Gray** · **Linearity** · **Phase** · **Brightness** · **Contrast** · **Y/C Delay** · **Diagonal**) |
+| **Video Tests** | Drop Shadow · **Striped Sprite** · Lag Test · **Manual Lag Test** · Timing & Reflex · Scroll · **Vertical Scroll** · Grid Scroll · Horiz/Vert Stripes · Checkerboard · Backlight Zone · **Alternate 240p/480i** |
 | **Audio Tests** | Sound Test · Audio Sync · **L/R Balance + 1 kHz Tone** · **MDFourier Sweep** |
 | **Hardware Tools** | Controller Test · **Pro Controller Test** · **Rotary Controller Test** · GPU Memory Viewer · DSP Memory Viewer · DRAM Memory Viewer · **System Info** · **Jaguar CD Probe** · **Video Mode Test** (Resolution Switching) |
 | **Screen Savers** | **Color Cycle** · **Bouncing Square** · **Scrolling Bars** |

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -2222,12 +2222,13 @@ void ScrollingBarsSaver(void){
  * Test pattern: Y/C Delay
  *
  * Canonical chroma-subsampling visualizer ported from the Artemio Urbina
- * suite. We render vertical strips of pure red, green and blue separated
- * by 1-pixel pure-white dividers. Cabling that carries true RGB (SCART RGB,
- * VGA, component on a clean path) keeps the dividers perfectly white --
- * the luma and chroma edges of each strip line up. Composite or S-Video
- * routes the chroma through a delay/notch filter, and the divider picks up
- * coloured fringing on either side as chroma trails luma.
+ * suite. We render six vertical strips -- red, green, blue, yellow, cyan
+ * and magenta -- separated by 1-pixel pure-white dividers. Cabling that
+ * carries true RGB (SCART RGB, VGA, component on a clean path) keeps the
+ * dividers perfectly white -- the luma and chroma edges of each strip line
+ * up. Composite or S-Video routes the chroma through a delay/notch filter,
+ * and the divider picks up coloured fringing on either side as chroma
+ * trails luma.
  *
  * Useful as a quick "is my SCART cable actually RGB?" check before trusting
  * the rest of the colour-bar suite.
@@ -2328,6 +2329,10 @@ void DrawDiagonal(void){
     settings->fadeToColor = 0x0000;
 
     buf = malloc(sizeof(uint16_t) * W * H);
+    /* Pre-clear so the first vsync after attach/show never displays the
+     * uninitialised malloc payload. The needRedraw branch below repaints
+     * the real diagonals on the first loop iteration. */
+    fillPACK_RGB16(buf, W * H, COLOR_BLACK);
 
     s = new_sprite(W, H, 0, 0 + settings->PALOffset, DEPTH16, buf);
     s->trans = 0;
@@ -2382,7 +2387,11 @@ void DrawDiagonal(void){
             buf2[20] = invert ? 'O' : 'O';
             buf2[21] = invert ? 'N' : 'F';
             buf2[22] = invert ? ' ' : 'F';
-            buf2[23] = '\0';
+            /* No trailing '\0' inside the visible 24-byte window: textBox's
+             * lineBreakAndWordWrap() walks i < tb->char_count and computes
+             * char_widths[tb->text[i]-32], so an embedded NUL would index
+             * the table at -32. The terminator already lives at
+             * tb->text[char_count] from newTextBox's allocation. */
             for(i = 0; i < 24; i++){ labelTb->text[i] = buf2[i]; }
             updateLine(settings, mainFont, labelTb, NULL, 999999, 999999, GREEN);
 
@@ -2463,7 +2472,8 @@ static void vertScrollUpdateLabel(textBox *tb, int speed, int dir, int paused){
     if(paused){
         line[18]='P'; line[19]='A'; line[20]='U'; line[21]='S'; line[22]='E';
     }
-    line[23] = '\0';
+    /* No embedded NUL inside the visible 24-byte window -- see DrawDiagonal
+     * label loop above. The terminator lives at tb->text[char_count]. */
     for(i = 0; i < 24; i++){ tb->text[i] = line[i]; }
     updateLine(settings, mainFont, tb, NULL, 999999, 999999, GREEN);
 }

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -2217,3 +2217,369 @@ void ScrollingBarsSaver(void){
     hide_or_show_display_layer_range(settings->d, 1, 0, 15);
     helpTb = freeTextBox(helpTb);
 }
+
+/* ---------------------------------------------------------------------------
+ * Test pattern: Y/C Delay
+ *
+ * Canonical chroma-subsampling visualizer ported from the Artemio Urbina
+ * suite. We render vertical strips of pure red, green and blue separated
+ * by 1-pixel pure-white dividers. Cabling that carries true RGB (SCART RGB,
+ * VGA, component on a clean path) keeps the dividers perfectly white --
+ * the luma and chroma edges of each strip line up. Composite or S-Video
+ * routes the chroma through a delay/notch filter, and the divider picks up
+ * coloured fringing on either side as chroma trails luma.
+ *
+ * Useful as a quick "is my SCART cable actually RGB?" check before trusting
+ * the rest of the colour-bar suite.
+ * --------------------------------------------------------------------------- */
+void DrawYCDelay(void){
+    const int W = 320, H = 240;
+    /* 6 colour strips on a black background, each strip flanked by a 1-pixel
+     * white divider. Width chosen so chroma fringing has room to develop
+     * across a typical CRT's PAL/NTSC chroma-delay window without strips
+     * bleeding into one another. */
+    const int STRIP_W = 48;
+    const int STRIP_COUNT = 6;
+    static const uint16_t strips[6] = {
+        COLOR_RED, COLOR_GREEN, COLOR_BLUE,
+        COLOR_YELLOW, COLOR_CYAN, COLOR_MAGENTA
+    };
+
+    int exit = 0;
+    int i, x0;
+    int totalW = STRIP_COUNT * STRIP_W + (STRIP_COUNT + 1);
+    int xStart = (W - totalW) / 2;
+
+    settings->fadeToColor = 0x0000;
+
+    uint16_t *buf = malloc(sizeof(uint16_t) * W * H);
+    fillPACK_RGB16(buf, W * H, COLOR_BLACK);
+
+    for(i = 0; i < STRIP_COUNT; i++){
+        x0 = xStart + i * (STRIP_W + 1);
+        rectPACK_RGB16(buf, W, x0 + 1, 16, STRIP_W, H - 32, strips[i]);
+        /* 1-pixel white divider on the leading edge -- this is the actual
+         * test target. On RGB it stays white; on composite it fringes. */
+        rectPACK_RGB16(buf, W, x0,             16, 1, H - 32, COLOR_WHITE);
+    }
+    /* Trailing divider after the last strip. */
+    rectPACK_RGB16(buf, W, xStart + STRIP_COUNT * (STRIP_W + 1), 16, 1, H - 32, COLOR_WHITE);
+
+    {
+        sprite *s = new_sprite(W, H, 0, 0 + settings->PALOffset, DEPTH16, buf);
+        s->trans = 0;
+        attach_sprite_to_display_at_layer(s, settings->d, 13);
+
+        hide_or_show_display_layer_range(settings->d, 1, 3, 15);
+
+        while(!exit){
+            read_joypad_state(settings->j_state);
+            settings->joy1 = settings->j_state->j1;
+            vsync();
+
+            if((settings->joy1 & 0xFFFFFF) == 0){
+                settings->controllerLock = 0;
+            }
+
+            if(((settings->joy1 & JOYPAD_DOWN) && (settings->joy1 & JOYPAD_OPTION)) && settings->controllerLock == 0){
+                settings->controllerLock = 1;
+                DrawHelp(HELP_YCDELAY);
+            }
+
+            if(extraExitPressed()){
+                settings->controllerLock = 1;
+                exit = 1;
+            }
+        }
+
+        hide_or_show_display_layer_range(settings->d, 0, 3, 15);
+        teardownFullscreenSprite(s, buf);
+    }
+}
+
+/* ---------------------------------------------------------------------------
+ * Test pattern: Diagonal / Clock
+ *
+ * Parallel 1-pixel diagonals at 45 degrees on a flat background. Stair-
+ * stepping is invisible on a CRT (the analogue beam smears the steps) and
+ * minimal on a 1:1 digital path, but upscalers (HDMI, OSSC, RetroTink,
+ * generic TV scaler ASICs) produce visibly different artefacts depending
+ * on their interpolation kernel. Shipping the same pattern at multiple
+ * spacings makes it easy to spot scaler kernels that handle dense edges
+ * differently from sparse ones.
+ *
+ * Controls:
+ *   D-pad UP/DOWN   -- cycle spacing 4 / 8 / 16 / 32 px
+ *   A               -- invert (white-on-black <-> black-on-white)
+ *   OPTION          -- exit
+ * --------------------------------------------------------------------------- */
+void DrawDiagonal(void){
+    const int W = 320, H = 240;
+    static const int SPACINGS[4] = { 4, 8, 16, 32 };
+    int spacingIdx = 1;        /* default 8 px to match upstream canonical */
+    int invert = 0;
+    int exit = 0;
+    int needRedraw = 1;
+
+    uint16_t *buf;
+    sprite *s;
+    textBox *labelTb;
+
+    settings->fadeToColor = 0x0000;
+
+    buf = malloc(sizeof(uint16_t) * W * H);
+
+    s = new_sprite(W, H, 0, 0 + settings->PALOffset, DEPTH16, buf);
+    s->trans = 0;
+    attach_sprite_to_display_at_layer(s, settings->d, 13);
+
+    /* Worst-case-sized label so newTextBox allocates a framebuffer wide
+     * enough; later updateLine calls only ever shorten the visible string. */
+    labelTb = newTextBox("SPACING: 32  INVERT: ON ", 192, 9, mainFont, 0, settings->d, 8, 8, 14, 1);
+    updateLine(settings, mainFont, labelTb, NULL, 999999, 999999, GREEN);
+
+    hide_or_show_display_layer_range(settings->d, 1, 3, 15);
+
+    while(!exit){
+        read_joypad_state(settings->j_state);
+        settings->joy1 = settings->j_state->j1;
+        vsync();
+
+        if(needRedraw){
+            int spacing = SPACINGS[spacingIdx];
+            uint16_t bg = invert ? COLOR_WHITE : COLOR_BLACK;
+            uint16_t fg = invert ? COLOR_BLACK : COLOR_WHITE;
+            int x, y, k;
+            char buf2[24];
+            int i;
+
+            fillPACK_RGB16(buf, W * H, bg);
+
+            /* Each diagonal satisfies x + y = k. Stepping k by `spacing`
+             * gives a family of equally-spaced parallel 45-degree lines
+             * that cover the full frame regardless of aspect. */
+            for(k = 0; k < (W + H); k += spacing){
+                for(y = 0; y < H; y++){
+                    x = k - y;
+                    if(x >= 0 && x < W){
+                        buf[y * W + x] = fg;
+                    }
+                }
+            }
+
+            /* Rebuild the label in-place. Width chosen to match the worst-
+             * case string so the sprite framebuffer never needs to grow. */
+            for(i = 0; i < 24; i++){ buf2[i] = ' '; }
+            buf2[0]='S'; buf2[1]='P'; buf2[2]='A'; buf2[3]='C'; buf2[4]='I'; buf2[5]='N'; buf2[6]='G'; buf2[7]=':';
+            if(spacing >= 10){
+                buf2[9] = '0' + (spacing / 10);
+                buf2[10] = '0' + (spacing % 10);
+            } else {
+                buf2[9] = '0' + spacing;
+                buf2[10] = ' ';
+            }
+            buf2[12]='I'; buf2[13]='N'; buf2[14]='V'; buf2[15]='E'; buf2[16]='R'; buf2[17]='T'; buf2[18]=':';
+            buf2[20] = invert ? 'O' : 'O';
+            buf2[21] = invert ? 'N' : 'F';
+            buf2[22] = invert ? ' ' : 'F';
+            buf2[23] = '\0';
+            for(i = 0; i < 24; i++){ labelTb->text[i] = buf2[i]; }
+            updateLine(settings, mainFont, labelTb, NULL, 999999, 999999, GREEN);
+
+            needRedraw = 0;
+        }
+
+        if((settings->joy1 & 0xFFFFFF) == 0){
+            settings->controllerLock = 0;
+        }
+
+        if(((settings->joy1 & JOYPAD_DOWN) && (settings->joy1 & JOYPAD_OPTION)) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            DrawHelp(HELP_DIAGONAL);
+            needRedraw = 1;
+        }
+
+        if((settings->joy1 & JOYPAD_UP) && !(settings->joy1 & JOYPAD_OPTION) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            spacingIdx = (spacingIdx + 1) & 3;
+            needRedraw = 1;
+        }
+
+        if((settings->joy1 & JOYPAD_DOWN) && !(settings->joy1 & JOYPAD_OPTION) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            spacingIdx = (spacingIdx + 3) & 3;
+            needRedraw = 1;
+        }
+
+        if((settings->joy1 & JOYPAD_A) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            invert ^= 1;
+            needRedraw = 1;
+        }
+
+        if(extraExitPressed()){
+            settings->controllerLock = 1;
+            exit = 1;
+        }
+    }
+
+    hide_or_show_display_layer_range(settings->d, 0, 3, 15);
+    labelTb = freeTextBox(labelTb);
+    teardownFullscreenSprite(s, buf);
+}
+
+/* ---------------------------------------------------------------------------
+ * Video test: Vertical Scroll
+ *
+ * Mirror of the existing horizontal Scroll Test from tests.c, scrolling
+ * top->bottom (or bottom->top) instead of side-to-side. Implemented
+ * procedurally so it doesn't need an LZ77-packed asset.
+ *
+ * The pattern is a 240-line repeating stripe (16-pixel-tall colour bands
+ * separated by 1-pixel white rules) that we shift by one pixel per frame
+ * by changing the sprite's y origin. Vertical OP/blitter pacing bugs --
+ * tearing, jitter, dropped lines -- show up here even when the existing
+ * horizontal scroll looks clean, because horizontal and vertical fetch
+ * paths exercise different parts of the OP list-walker.
+ *
+ * Controls:
+ *   D-pad UP/DOWN    -- speed (1, 2, 4 px/frame; 0 = paused)
+ *   D-pad LEFT/RIGHT -- reverse direction
+ *   A                -- pause toggle
+ *   OPTION           -- exit
+ * --------------------------------------------------------------------------- */
+
+/* HUD label rebuild for VertScrollTest, factored out so the per-frame loop
+ * stays small enough not to trip GCC 4.x's reload pass on m68k at -O2. */
+static void vertScrollUpdateLabel(textBox *tb, int speed, int dir, int paused){
+    int i;
+    char line[24];
+    for(i = 0; i < 24; i++){ line[i] = ' '; }
+    line[0]='S'; line[1]='P'; line[2]='E'; line[3]='E'; line[4]='D'; line[5]=':';
+    line[7] = (char)('0' + (paused ? 0 : speed));
+    line[9]='D'; line[10]='I'; line[11]='R'; line[12]=':';
+    if(dir > 0){ line[14]='D'; line[15]='N'; }
+    else       { line[14]='U'; line[15]='P'; }
+    if(paused){
+        line[18]='P'; line[19]='A'; line[20]='U'; line[21]='S'; line[22]='E';
+    }
+    line[23] = '\0';
+    for(i = 0; i < 24; i++){ tb->text[i] = line[i]; }
+    updateLine(settings, mainFont, tb, NULL, 999999, 999999, GREEN);
+}
+
+/* Stripe-pattern fill for the doubled framebuffer. Pulled out so the
+ * caller's stack frame stays slim. */
+static void vertScrollFillBuffer(uint16_t *buf, int W, int H, int BUF_H){
+    static const uint16_t bands[6] = {
+        COLOR_RED, COLOR_YELLOW, COLOR_GREEN,
+        COLOR_CYAN, COLOR_BLUE, COLOR_MAGENTA
+    };
+    const int BAND_H = 16;
+    int x, y;
+    for(y = 0; y < BUF_H; y++){
+        int yMod = y % H;
+        int b = (yMod / BAND_H) % 6;
+        uint16_t c = ((yMod % BAND_H) == 0) ? COLOR_WHITE : bands[b];
+        for(x = 0; x < W; x++){
+            buf[y * W + x] = c;
+        }
+    }
+}
+
+void VertScrollTest(void){
+    const int W = 320;
+    const int H = 240;
+    const int BUF_H = 480;
+
+    int exit = 0;
+    int paused = 0;
+    int speed = 1;
+    int dir = 1;
+    int yOff = 0;
+    int needLabel = 1;
+
+    uint16_t *buf;
+    sprite *s;
+    textBox *labelTb;
+
+    settings->fadeToColor = 0x0000;
+
+    buf = malloc(sizeof(uint16_t) * W * BUF_H);
+    fillPACK_RGB16(buf, W * BUF_H, COLOR_BLACK);
+    vertScrollFillBuffer(buf, W, H, BUF_H);
+
+    s = new_sprite(W, BUF_H, 0, 0 + settings->PALOffset, DEPTH16, buf);
+    s->trans = 0;
+    attach_sprite_to_display_at_layer(s, settings->d, 13);
+
+    labelTb = newTextBox("SPEED: 4 DIR: UP   PAUSE", 200, 9, mainFont, 0, settings->d, 8, 8, 14, 1);
+    updateLine(settings, mainFont, labelTb, NULL, 999999, 999999, GREEN);
+
+    hide_or_show_display_layer_range(settings->d, 1, 3, 15);
+
+    while(!exit){
+        read_joypad_state(settings->j_state);
+        settings->joy1 = settings->j_state->j1;
+        vsync();
+
+        if(!paused){
+            yOff += dir * speed;
+            if(yOff <= -H) yOff += H;
+            if(yOff > 0)   yOff -= H;
+            s->y = yOff + settings->PALOffset;
+        }
+
+        if(needLabel){
+            vertScrollUpdateLabel(labelTb, speed, dir, paused);
+            needLabel = 0;
+        }
+
+        if((settings->joy1 & 0xFFFFFF) == 0){
+            settings->controllerLock = 0;
+        }
+
+        if(settings->controllerLock != 0){
+            continue;
+        }
+
+        if((settings->joy1 & JOYPAD_DOWN) && (settings->joy1 & JOYPAD_OPTION)){
+            settings->controllerLock = 1;
+            DrawHelp(HELP_VERTSCROLL);
+            needLabel = 1;
+        }
+        else if((settings->joy1 & JOYPAD_UP)){
+            settings->controllerLock = 1;
+            if(speed < 4) speed <<= 1;
+            needLabel = 1;
+        }
+        else if((settings->joy1 & JOYPAD_DOWN)){
+            settings->controllerLock = 1;
+            if(speed > 1) speed >>= 1;
+            needLabel = 1;
+        }
+        else if((settings->joy1 & JOYPAD_LEFT)){
+            settings->controllerLock = 1;
+            dir = -1;
+            needLabel = 1;
+        }
+        else if((settings->joy1 & JOYPAD_RIGHT)){
+            settings->controllerLock = 1;
+            dir = 1;
+            needLabel = 1;
+        }
+        else if((settings->joy1 & JOYPAD_A)){
+            settings->controllerLock = 1;
+            paused ^= 1;
+            needLabel = 1;
+        }
+        else if((settings->joy1 & JOYPAD_OPTION)){
+            settings->controllerLock = 1;
+            exit = 1;
+        }
+    }
+
+    hide_or_show_display_layer_range(settings->d, 0, 3, 15);
+    labelTb = freeTextBox(labelTb);
+    teardownFullscreenSprite(s, buf);
+}

--- a/extra_tests.h
+++ b/extra_tests.h
@@ -35,10 +35,13 @@ void DrawLinearity(void);
 void DrawPhase(void);
 void DrawBrightness(void);
 void DrawContrast(void);
+void DrawYCDelay(void);
+void DrawDiagonal(void);
 
 /* Video tests */
 void ManualLagTest(void);
 void Alternate240p480iTest(void);
+void VertScrollTest(void);
 
 /* Audio tests */
 void AudioBalanceTest(void);

--- a/help.c
+++ b/help.c
@@ -554,7 +554,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "Y/C DELAY", 999999, 999999, GREEN);
 
-                            updateLine(settings, mainFont, helpTextBox, "Vertical strips of pure red, green and blue separated by 1px white dividers.^^On a clean RGB path the dividers stay white. On composite/S-Video, chroma trails luma so the divider picks up coloured fringing on either side -- that is the visible Y/C delay.^^Useful to confirm a SCART/component cable is really running RGB and not falling back to composite.", 999999, 999999, WHITE);
+                            updateLine(settings, mainFont, helpTextBox, "Vertical strips of red, green, blue, yellow, cyan and magenta separated by 1px white dividers.^^On a clean RGB path the dividers stay white. On composite/S-Video, chroma trails luma so the divider picks up coloured fringing on either side -- that is the visible Y/C delay.^^Useful to confirm a SCART/component cable is really running RGB and not falling back to composite.", 999999, 999999, WHITE);
                         break;
                     }
 

--- a/help.c
+++ b/help.c
@@ -101,6 +101,9 @@ void DrawHelp(int option){
         case HELP_STRIPED:
         case HELP_SOUND:
         case HELP_SPRITE_STRESS:
+        case HELP_YCDELAY:
+        case HELP_DIAGONAL:
+        case HELP_VERTSCROLL:
             totalPages = 1;
         break;
 
@@ -476,7 +479,7 @@ void DrawHelp(int option){
                     switch(page){
                         
                         case 0:
-                            updateLine(settings, mainFont, helpLineTextBox[0], "BACKLIT TEST", 999999, 999999, GREEN);
+                            updateLine(settings, mainFont, helpLineTextBox[0], "BACKLIGHT TEST", 999999, 999999, GREEN);
                             
                             updateLine(settings, mainFont, helpTextBox, "This test allows you to check how the display's backlight works when only a small array of pixels is shown.^^The user can move around the white pixel arrays with the d-pad, and change the size of the pixel array with 'A'. The 'B' button allows the user to hide the pixel array in order to alternate a fully black screen.", 999999, 999999, WHITE);  
                         break;
@@ -543,9 +546,46 @@ void DrawHelp(int option){
                     }
 
                 break;
-                
-                
-                
+
+                case HELP_YCDELAY:
+
+                    switch(page){
+
+                        case 0:
+                            updateLine(settings, mainFont, helpLineTextBox[0], "Y/C DELAY", 999999, 999999, GREEN);
+
+                            updateLine(settings, mainFont, helpTextBox, "Vertical strips of pure red, green and blue separated by 1px white dividers.^^On a clean RGB path the dividers stay white. On composite/S-Video, chroma trails luma so the divider picks up coloured fringing on either side -- that is the visible Y/C delay.^^Useful to confirm a SCART/component cable is really running RGB and not falling back to composite.", 999999, 999999, WHITE);
+                        break;
+                    }
+
+                break;
+
+                case HELP_DIAGONAL:
+
+                    switch(page){
+
+                        case 0:
+                            updateLine(settings, mainFont, helpLineTextBox[0], "DIAGONAL / CLOCK", 999999, 999999, GREEN);
+
+                            updateLine(settings, mainFont, helpTextBox, "Parallel 1-pixel diagonal lines at 45 degrees.^^On a CRT or a clean digital path each line is a clean stair-step. Upscalers (HDMI, OSSC, RetroTink) reveal stair-stepping or blur artefacts here.^^UP/DOWN: change line spacing (4/8/16/32 px). A: invert (white-on-black <-> black-on-white). OPTION: exit.", 999999, 999999, WHITE);
+                        break;
+                    }
+
+                break;
+
+                case HELP_VERTSCROLL:
+
+                    switch(page){
+
+                        case 0:
+                            updateLine(settings, mainFont, helpLineTextBox[0], "VERTICAL SCROLL", 999999, 999999, GREEN);
+
+                            updateLine(settings, mainFont, helpTextBox, "A full-screen banded pattern scrolls top-to-bottom (or bottom-to-top) at a user-selectable speed. Mirror of the horizontal Scroll Test, exercising vertical OP/blitter pacing.^^UP/DOWN: speed. LEFT/RIGHT: reverse direction. A: pause. OPTION: exit.^^Vertical jitter, tearing or pacing hitches that don't show up in horizontal scroll usually surface here.", 999999, 999999, WHITE);
+                        break;
+                    }
+
+                break;
+
             }
             
             hide_or_show_display_layer_range(settings->d, 1, 14, 15);

--- a/help.h
+++ b/help.h
@@ -45,6 +45,9 @@
 #define HELP_LAG 24
 #define HELP_CONVERGENCE 32
 #define HELP_SPRITE_STRESS 33
+#define HELP_YCDELAY 34
+#define HELP_DIAGONAL 35
+#define HELP_VERTSCROLL 36
 
 extern uint8_t help;
 phrase *helpData;

--- a/main.c
+++ b/main.c
@@ -539,7 +539,10 @@ void testPatternMenu(){
 void morePatternsMenu(){
 
     int done = 0;
-    int lastMenuLine = 6; //counting from zero
+    /* 7 patterns + Back (case 8). Y/C Delay and Diagonal are added here
+     * rather than testPatternMenu because that page already runs to 16
+     * lines and adding more would push the cursor row off the safe area. */
+    int lastMenuLine = 8;
     settings->menuState = 1;
 
     hide_display_layer(settings->d, 2);
@@ -555,8 +558,10 @@ void morePatternsMenu(){
     updateLine(settings, mainFont, lineTextBox[3], "Phase", settings->lineXOffset, setLineYPos(2), WHITE);
     updateLine(settings, mainFont, lineTextBox[4], "Brightness", settings->lineXOffset, setLineYPos(3), WHITE);
     updateLine(settings, mainFont, lineTextBox[5], "Contrast", settings->lineXOffset, setLineYPos(4), WHITE);
+    updateLine(settings, mainFont, lineTextBox[6], "Y/C Delay", settings->lineXOffset, setLineYPos(5), WHITE);
+    updateLine(settings, mainFont, lineTextBox[7], "Diagonal / Clock", settings->lineXOffset, setLineYPos(6), WHITE);
 
-    updateLine(settings, mainFont, lineTextBox[6], "Back to Test Patterns", settings->lineXOffset, setLineYPos(6), WHITE);
+    updateLine(settings, mainFont, lineTextBox[8], "Back to Test Patterns", settings->lineXOffset, setLineYPos(8), WHITE);
 
     updateLine(settings, mainFont, lineTextBox[0], settings->PALNTSC ? "NTSC VDP 320x240p" : "PAL VDP 320x288p", 184, 200 + settings->PALOffset, WHITE);
 
@@ -619,9 +624,11 @@ void morePatternsMenu(){
                 case 3: DrawPhase();        break;
                 case 4: DrawBrightness();   break;
                 case 5: DrawContrast();     break;
+                case 6: DrawYCDelay();      break;
+                case 7: DrawDiagonal();     break;
 
                 //return to Test Patterns menu
-                case 6:
+                case 8:
                     done = 1;
                 break;
 
@@ -736,7 +743,9 @@ void ScreenSaversMenu(){
 void VideoTestsMenu(){
     
     int done = 0;
-    int lastMenuLine = 14; //counting from zero
+    /* Vertical Scroll Test added immediately after the existing horizontal
+     * Scroll Test, so every following entry shifts down by one slot. */
+    int lastMenuLine = 15;
     settings->menuState = 1;
     
     hide_display_layer(settings->d, 2);
@@ -753,15 +762,16 @@ void VideoTestsMenu(){
     updateLine(settings, mainFont, lineTextBox[4], "Manual Lag Test", settings->lineXOffset, setLineYPos(3), WHITE);
     updateLine(settings, mainFont, lineTextBox[5], "Timing & Reflex Test", settings->lineXOffset, setLineYPos(4), WHITE);
     updateLine(settings, mainFont, lineTextBox[6], "Scroll Test", settings->lineXOffset, setLineYPos(5), WHITE);
-    updateLine(settings, mainFont, lineTextBox[7], "Grid Scroll Test", settings->lineXOffset, setLineYPos(6), WHITE);
-    updateLine(settings, mainFont, lineTextBox[8], "Horiz/Vert Stripes", settings->lineXOffset, setLineYPos(7), WHITE);
-    updateLine(settings, mainFont, lineTextBox[9], "Checkerboard", settings->lineXOffset, setLineYPos(8), WHITE);
-    updateLine(settings, mainFont, lineTextBox[10], "Backlit Zone Test", settings->lineXOffset, setLineYPos(9), WHITE);
-    updateLine(settings, mainFont, lineTextBox[11], "Alternate 240p/480i", settings->lineXOffset, setLineYPos(10), WHITE);
+    updateLine(settings, mainFont, lineTextBox[7], "Vertical Scroll Test", settings->lineXOffset, setLineYPos(6), WHITE);
+    updateLine(settings, mainFont, lineTextBox[8], "Grid Scroll Test", settings->lineXOffset, setLineYPos(7), WHITE);
+    updateLine(settings, mainFont, lineTextBox[9], "Horiz/Vert Stripes", settings->lineXOffset, setLineYPos(8), WHITE);
+    updateLine(settings, mainFont, lineTextBox[10], "Checkerboard", settings->lineXOffset, setLineYPos(9), WHITE);
+    updateLine(settings, mainFont, lineTextBox[11], "Backlight Zone Test", settings->lineXOffset, setLineYPos(10), WHITE);
+    updateLine(settings, mainFont, lineTextBox[12], "Alternate 240p/480i", settings->lineXOffset, setLineYPos(11), WHITE);
     
-    updateLine(settings, mainFont, lineTextBox[12], "Help", settings->lineXOffset, setLineYPos(12), WHITE);
-    updateLine(settings, mainFont, lineTextBox[13], "Options", settings->lineXOffset, setLineYPos(13), WHITE);
-    updateLine(settings, mainFont, lineTextBox[14], "Back to Main Menu", settings->lineXOffset, setLineYPos(14), WHITE);
+    updateLine(settings, mainFont, lineTextBox[13], "Help", settings->lineXOffset, setLineYPos(13), WHITE);
+    updateLine(settings, mainFont, lineTextBox[14], "Options", settings->lineXOffset, setLineYPos(14), WHITE);
+    updateLine(settings, mainFont, lineTextBox[15], "Back to Main Menu", settings->lineXOffset, setLineYPos(15), WHITE);
     
     updateLine(settings, mainFont, lineTextBox[0], settings->PALNTSC ? "NTSC VDP 320x240p" : "PAL VDP 320x288p", 184, 200 + settings->PALOffset, WHITE);
        
@@ -866,44 +876,51 @@ void VideoTestsMenu(){
                     HScrollTest();
                     
                 break;
-                    
-                //VScrollTest
+
+                //VertScrollTest (procedural mirror of horizontal Scroll Test)
                 case 7:
+
+                    VertScrollTest();
+
+                break;
+
+                //VScrollTest (canonical "Grid Scroll" backed by an LZ77 asset)
+                case 8:
                     
                     VScrollTest();
                     
                 break;
                     
                 //DrawStripes
-                case 8:
+                case 9:
                     
                     DrawStripes();
                     
                 break;
                     
                 //DrawCheckBoard
-                case 9:
+                case 10:
                     
                     DrawCheckBoard();
                     
                 break;
                     
                 //LEDZoneTest
-                case 10:
+                case 11:
                     
                     LEDZoneTest();
                     
                 break;
                     
                 //Alternate240p480i
-                case 11:
+                case 12:
 
                     Alternate240p480iTest();
 
                 break;
                     
                 //DrawHelp
-                case 12:
+                case 13:
 
                     hide_or_show_display_layer_range(settings->d, 0, 0, 15);
                     hide_or_show_display_layer_range(settings->d, 1, 14, 14);
@@ -915,14 +932,14 @@ void VideoTestsMenu(){
                 break;
                     
                 //OptionsMenu
-                case 13:
+                case 14:
 
                     OptionsMenu();
 
                 break;
                     
                 //return to main menu
-                case 14:
+                case 15:
                     
                     done = 1;
                     


### PR DESCRIPTION
## Summary

This PR adds three canonical 240p Test Suite patterns to the Jaguar build and fixes the long-standing "Backlit Zone Test" misnomer noted in BitJag #13.

All four deliverables ship on a single branch (`feat/canonical-patterns-and-vert-scroll`).

### 1. Y/C Delay test pattern (More Patterns submenu)

Vertical strips of pure red, green, blue, yellow, cyan and magenta separated by 1-pixel pure-white dividers on a black background. Canonical chroma-subsampling visualizer.

- On a clean RGB path (SCART RGB, VGA, component on a clean run) the dividers stay perfectly white.
- On composite or S-Video the chroma trails the luma and the dividers pick up coloured fringing on either side.
- Use it as a quick "is my SCART cable actually RGB?" check before trusting the rest of the colour-bar suite.

Controls: `OPTION` exits, `DOWN+OPTION` opens the per-test help screen.

### 2. Diagonal / Clock pattern (More Patterns submenu)

Parallel 1-pixel-wide diagonal lines at 45° on a flat background. Stair-stepping is invisible on a CRT and minimal on a 1:1 digital path, but upscalers (HDMI, OSSC, RetroTink, generic TV scaler ASICs) reveal kernel-dependent artefacts.

- Spacing is user-cyclable through 4 / 8 / 16 / 32 pixels (D-pad UP/DOWN) so users can spot kernels that handle dense edges differently from sparse ones.
- `A` inverts the colour scheme (white-on-black ↔ black-on-white) for displays that show different artefacts depending on polarity.
- HUD label reflects current spacing and invert state.

Controls: `UP`/`DOWN` cycle spacing, `A` invert, `OPTION` exit, `DOWN+OPTION` help.

### 3. Vertical Scroll Test (Video Tests menu)

Procedural mirror of the existing horizontal Scroll Test, scrolling top↔bottom instead of side-to-side. Slotted directly after the existing horizontal Scroll Test entry.

- Pattern is a 16-pixel-tall repeating colour band with 1-pixel white rules between bands.
- Internally uses a doubled (480-line) framebuffer so wrap-around is just a sprite y-origin reset, never a tear-prone memmove.
- Exercises a different OP/blitter fetch path than the horizontal test, surfacing pacing bugs (vertical jitter, dropped lines, tearing) the horizontal test cannot.
- Controls: D-pad UP/DOWN change speed (1/2/4 px/frame), LEFT/RIGHT reverse direction, `A` pauses, `OPTION` exits.
- Helper functions (`vertScrollFillBuffer`, `vertScrollUpdateLabel`) extracted to keep the main loop's stack frame small enough to avoid tripping GCC 4.x's `reload1` ICE on m68k at `-O2` (the original single-function version triggered an internal compiler error during register allocation).

### 4. Typo fix — "Backlit Zone Test" → "Backlight Zone Test" (closes BitJag #13)

Renamed everywhere it appears:

- `main.c` — Video Tests menu entry
- `help.c` — `BACKLIT TEST` help title → `BACKLIGHT TEST`
- `README.md` — Video Tests row of the test matrix

The Checkerboard `"auto-toggle each auto-toggle each"` duplicate also called out in BitJag #13 was verified absent in this fork (no source change needed).

## Implementation notes

- All three new tests are **procedural** — no new LZ77-packed assets ship with the cart, ROM stays exactly 1 MiB (`1,048,576` bytes).
- Per-test help screens added with `HELP_YCDELAY` / `HELP_DIAGONAL` / `HELP_VERTSCROLL` enums in `help.h` and matching `case` arms in `help.c`'s `DrawHelp()` switch.
- `morePatternsMenu()` grows from 5 entries to 7; the "Back to Test Patterns" cursor target moves from `case 6` to `case 8`.
- `VideoTestsMenu()` shifts every entry after the existing horizontal `Scroll Test` down by one slot (`Grid Scroll Test` → `lineTextBox[8]`, …, `Back to Main Menu` → `lineTextBox[15]`); `lastMenuLine` bumps from 14 to 15. The new layout still fits inside the NTSC 240p safe area (bottom menu line at y=191, status line at y=200).
- `textBox` widths are kept multiples of 8 (phrase-aligned for `DEPTH8` sprites) and initialised with their worst-case strings so the sprite framebuffer is sized correctly upfront — `updateLine()` only ever shortens visible text, never widens it.
- The pre-existing `-Wincompatible-pointer-types` warnings on every `new_sprite()` call in `extra_tests.c` are inherited by the new functions; no behavioural difference.
- Version string in `drawCredits()` intentionally **not** bumped — releases are tagged separately by a release PR.

## Build status

- `make docker-rom` builds **clean** (no new warnings beyond the pre-existing `new_sprite` pointer-type set).
- Output: `jag_240p_test_suite.rom`, **1,048,576 bytes** (1 MiB), checksum `0x11D559FC`.
- `make test` (libretro smoke) and `make screenshots` were intentionally skipped — the parent agent will run those after merge, and the screenshot gallery for the three new patterns will be regenerated then.

## Files changed

| File | Change |
|------|--------|
| `main.c` | Backlit→Backlight typo; `morePatternsMenu()` extended with Y/C Delay + Diagonal entries; `VideoTestsMenu()` extended with `Vertical Scroll Test` entry and shifted dispatch |
| `help.c` | `BACKLIT`→`BACKLIGHT` title; new help arms for `HELP_YCDELAY`, `HELP_DIAGONAL`, `HELP_VERTSCROLL` |
| `help.h` | Three new `HELP_*` enum values |
| `extra_tests.h` | Forward declarations for `DrawYCDelay`, `DrawDiagonal`, `VertScrollTest` |
| `extra_tests.c` | Implementations for the three new tests + two `static` helpers |
| `README.md` | Test-matrix row updated for the typo and the three new tests |

Closes BitJag/atari_jaguar_240p_test_suite#13

---

Made with [Cursor](https://cursor.com)