### PR TITLE
release: 1.0.0 (sprite stress + canonical patterns + audio noise/separation)

### DIFF
--- a/main.c
+++ b/main.c
@@ -1400,7 +1400,7 @@ void drawCredits(){
                     updateLine(settings, mainFont, lineTextBox[16], "Advisor:", settings->lineXOffset, setLineYPos(15), GREEN);
                     updateLine(settings, mainFont, lineTextBox[17], "  ()  ", settings->lineXOffset, setLineYPos(16), WHITE);
 
-                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 0.7.3 - 04/22/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
+                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 1.0.0 - 04/22/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
 
                     updateLine(settings, mainFont, lineTextBox[19], "Option - Return To Main Menu", settings->lineXOffset, setLineYPos(18) + 4, WHITE);
                 break;


### PR DESCRIPTION
## Summary

Cuts the **1.0 milestone**, marking parity with the canonical 240p Test Suite feature set on Atari Jaguar.

This release rolls up the three parallel feature PRs that landed against `v0.7.3`:

| PR  | Feature                                                                                          |
| --- | ------------------------------------------------------------------------------------------------ |
| #12 | **Sprite Stress Test** (OP saturation harness, Hardware Tools menu)                              |
| #13 | **Y/C Delay**, **Diagonal / Clock**, **Vertical Scroll** patterns + `Backlit→Backlight` typo fix (closes BitJag #13) |
| #14 | **White Noise**, **Pink Noise**, **L/R Channel Separation** tests (Audio Tests menu)             |

The 1.0 designation reflects feature-completeness against the upstream BitJag test matrix. Future 1.x releases cover additions (PAL polish, Jaguar CD) without further breaking changes to the menu structure.

## Changes

- `main.c` — version string bumped from `0.7.3` to `1.0.0`.
- ROM checksum `0x76CA8651`, size `2,097,152` bytes (2 MiB), built clean against `make docker-rom`.

## Release pipeline

Once this PR is merged, tagging `v1.0.0` on the squash-merge commit will trigger `release.yml` which builds release / debug artifacts and publishes them to the GitHub Releases page (same flow used for `v0.7.3`).

Made with [Cursor](https://cursor.com).