### PR TITLE
Address Copilot review on merged PR #24 (Jaguar CD probe)

### DIFF
--- a/extra_tests.c
+++ b/extra_tests.c
@@ -1823,12 +1823,28 @@ void MDFourierTest(void){
  * sanity check that the CD's data bus is alive without booting media.
  * --------------------------------------------------------------------------- */
 static void jagCdSetHex4(textBox *tb, char *buf, uint16_t v){
-    int n, i, pad;
+    int n, i, pad, j, hexStart;
     itostring(buf, (int)v, 16);
     n = 0;
     while(buf[n] != '\0' && n < 4) n++;
-    for(pad = 0; pad < 4 - n; pad++) tb->text[10 + pad] = '0';
-    for(i = 0; i < n; i++) tb->text[10 + (4 - n) + i] = buf[i];
+    /* Find first digit of the 4-hex field (after " : " in labels like
+     * "$F14000 : 0000 ") so rewording the prefix does not desync a hard
+     * offset; fall back to 10 to match the initial template layout. */
+    hexStart = 10;
+    if(tb != NULL && tb->text != NULL){
+        j = 0;
+        while(tb->text[j] != '\0' && tb->text[j] != ':'){
+            j++;
+            if(j > 120) break;
+        }
+        if(tb->text[j] == ':'){
+            j++;
+            while(tb->text[j] == ' ') j++;
+            hexStart = j;
+        }
+    }
+    for(pad = 0; pad < 4 - n; pad++) tb->text[hexStart + pad] = '0';
+    for(i = 0; i < n; i++) tb->text[hexStart + (4 - n) + i] = buf[i];
 }
 
 void JaguarCDTest(void){
@@ -1854,7 +1870,7 @@ void JaguarCDTest(void){
     textBox *dTb = newTextBox("$F14008 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 128, 13, 1);
     textBox *eTb = newTextBox("$800000 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 144, 13, 1);
     textBox *noteTb = newTextBox("LIVE/frm: hex refresh  0000+FFFF=open", 256, 9, mainFont, 0, settings->d, 16, 168, 13, 1);
-    textBox *helpTb = newTextBox("DOWN+OPT: help   OPTION: exit", 256, 9, mainFont, 0, settings->d, 32, 196, 13, 1);
+    textBox *helpTb = newTextBox("DOWN+OPTION: help   OPTION: exit", 256, 9, mainFont, 0, settings->d, 32, 196, 13, 1);
     updateLine(settings, mainFont, noteTb, NULL, 999999, 999999, GREY);
     updateLine(settings, mainFont, helpTb, NULL, 999999, 999999, GREY);
 

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -1822,25 +1822,58 @@ void MDFourierTest(void){
  * and is purely informational. On a Jag CD it gives the user a quick
  * sanity check that the CD's data bus is alive without booting media.
  * --------------------------------------------------------------------------- */
+/* jlibc has no strstr; only used for short footer phrases here. */
+static int extraTextStrstrIndex(const char *hay, const char *needle){
+    int i, j;
+    if(hay == NULL || needle == NULL){ return -1; }
+    if(needle[0] == '\0'){ return 0; }
+    for(i = 0; hay[i] != '\0'; i++){
+        for(j = 0; needle[j] != '\0' && hay[i + j] == needle[j]; j++){ /* match */ }
+        if(needle[j] == '\0'){ return i; }
+        if(hay[i + j] == '\0'){ return -1; }
+    }
+    return -1;
+}
+
+/* GREY body text, GREEN on "DOWN+OPTION" — same idea as help.c highlight. */
+static void extraHighlightJagCdFooterLine(textBox *tb){
+    const char *phrase = "DOWN+OPTION";
+    int start, plen;
+    if(tb == NULL || tb->text == NULL){ return; }
+    start = extraTextStrstrIndex((const char *)tb->text, phrase);
+    if(start < 0){ return; }
+    plen = 0;
+    while(phrase[plen] != '\0'){ plen++; }
+    textRangeColorChange(tb, start, plen, GREY, GREEN);
+}
+
 static void jagCdSetHex4(textBox *tb, char *buf, uint16_t v){
-    int n, i, pad, j, hexStart;
+    int n, i, pad, j, hexStart, cmax;
+    if(tb == NULL || tb->text == NULL){ return; }
     itostring(buf, (int)v, 16);
     n = 0;
     while(buf[n] != '\0' && n < 4) n++;
-    /* Find first digit of the 4-hex field (after " : " in labels like
-     * "$F14000 : 0000 ") so rewording the prefix does not desync a hard
-     * offset; fall back to 10 to match the initial template layout. */
+    /* Find the 4-hex run after " : " using char_count; never write past
+     * the buffer. Fall back to offset 10 for the shipped templates. */
+    cmax = tb->char_count;
     hexStart = 10;
-    if(tb != NULL && tb->text != NULL){
-        j = 0;
-        while(tb->text[j] != '\0' && tb->text[j] != ':'){
+    j = 0;
+    while(j < cmax && tb->text[j] != '\0' && tb->text[j] != ':'){
+        j++;
+    }
+    if(j < cmax && tb->text[j] == ':'){
+        j++;
+        while(j < cmax && tb->text[j] == ' '){
             j++;
-            if(j > 120) break;
         }
-        if(tb->text[j] == ':'){
-            j++;
-            while(tb->text[j] == ' ') j++;
+        if(j + 4 <= cmax){
             hexStart = j;
+        }
+    }
+    if(hexStart + 4 > cmax){
+        hexStart = 10;
+        if(hexStart + 4 > cmax){
+            return;
         }
     }
     for(pad = 0; pad < 4 - n; pad++) tb->text[hexStart + pad] = '0';
@@ -1873,6 +1906,7 @@ void JaguarCDTest(void){
     textBox *helpTb = newTextBox("DOWN+OPTION: help   OPTION: exit", 256, 9, mainFont, 0, settings->d, 32, 196, 13, 1);
     updateLine(settings, mainFont, noteTb, NULL, 999999, 999999, GREY);
     updateLine(settings, mainFont, helpTb, NULL, 999999, 999999, GREY);
+    extraHighlightJagCdFooterLine(helpTb);
 
     hide_or_show_display_layer_range(settings->d, 1, 3, 15);
 

--- a/help.c
+++ b/help.c
@@ -638,7 +638,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "JAGUAR CD PROBE", 999999, 999999, GREEN);
 
-                            updateLine(settings, mainFont, helpTextBox, "Probes a handful of 16-bit words: four in the Butch (CD) ASIC at $F14000+ and the first word of the paged-in CD boot ROM window at $00800000. On a base Jaguar with no CD, those often read 0x0000 or 0xFFFF (open bus).^If *any* word returns a different value, the heuristic reports DETECTED.^Values are re-read *every frame* so emulators and hardware bring-up can watch registers change in real time. This is not a full Memory-Track or disc I/O test -- use real media for that.^^DOWN+OPTION: this help.   OPTION: exit", 999999, 999999, WHITE);
+                            updateLine(settings, mainFont, helpTextBox, "Probes a handful of 16-bit words: four in the Butch (CD) ASIC at $F14000+ and the first word of the paged-in CD boot ROM window at $800000. On a base Jaguar with no CD, those often read 0x0000 or 0xFFFF (open bus).^If *any* word returns a different value, the heuristic reports DETECTED.^Values are re-read *every frame* so emulators and hardware bring-up can watch registers change in real time. This is not a full Memory-Track or disc I/O test -- use real media for that.^^DOWN+OPTION: this help.   OPTION: exit", 999999, 999999, WHITE);
                             highlightHelpPhrase(helpTextBox, "DOWN+OPTION");
                         break;
                     }


### PR DESCRIPTION
## Why
[PR #24](https://github.com/JoeMatt/atari_jaguar_240p_test_suite/pull/24) was merged while GitHub Copilot’s line review was still in flight; the three comments were posted after the merge. This PR applies that feedback on `main`.

## Changes (Copilot)
1. **`jagCdSetHex4`**: find the 4-hex run after `:` and spaces instead of a fixed `text[10]` index (keeps fallback to `10` if no `:`), so label prefix edits are less fragile.
2. **Footer** (`extra_tests.c`): `DOWN+OPTION: help` to match the help page and `highlightHelpPhrase("DOWN+OPTION")`.
3. **`help.c`**: CD BIOS window phrasing uses `$800000` to match the probe row label (previously only `$00800000` in prose).

## Test
- `make docker-rom` passed locally.

## Does not
- Revert or re-open #24 (already on `main`).