### PR TITLE
release: bump version to 1.1.0 (full PAL pass)

### DIFF
--- a/main.c
+++ b/main.c
@@ -1400,7 +1400,7 @@ void drawCredits(){
                     updateLine(settings, mainFont, lineTextBox[16], "Advisor:", settings->lineXOffset, setLineYPos(15), GREEN);
                     updateLine(settings, mainFont, lineTextBox[17], "  ()  ", settings->lineXOffset, setLineYPos(16), WHITE);
 
-                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 1.0.2 - 04/23/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
+                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 1.1.0 - 04/27/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
 
                     updateLine(settings, mainFont, lineTextBox[19], "Option - Return To Main Menu", settings->lineXOffset, setLineYPos(18) + 4, WHITE);
                 break;


### PR DESCRIPTION
## Summary
- Bump credits version string to `Ver. 1.1.0 - 04/27/2026`
- Marks the full PAL correctness pass (region override, procedural pattern geometry, audio timing, VDP diagnostics, text centering) as a release milestone

## After merge
Tag with `v1.1.0` to trigger `release.yml`:
```
git tag v1.1.0 && git push origin v1.1.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)