### PR TITLE
feat(cd): Memory Track EEPROM test + expanded CD probe

### DIFF
--- a/eeprom_test.c
+++ b/eeprom_test.c
@@ -199,8 +199,7 @@ int eeprom_write_word_drv(uint8_t addr, uint16_t data){
  * recoloring the active row -- same pattern as the controller test.
  * --------------------------------------------------------------------------- */
 
-#define GRID_COLS 8
-#define GRID_ROWS 8
+/* GRID_COLS / GRID_ROWS moved to eeprom_test.h as EE_GRID_COLS / EE_GRID_ROWS */
 /* Grid sits at x=0 with a full-screen 320 px wide sprite per row.
  * That gives the 43-char "00: 0000 0000 ..." line ~62 px of right-
  * margin slack at 6 px/char so the in-engine word-wrap can never
@@ -213,43 +212,29 @@ int eeprom_write_word_drv(uint8_t addr, uint16_t data){
 #define GRID_Y 80
 #define GRID_ROW_H 14
 
-static void hexbyte(char *out, uint8_t v){
-    /* No printf in this codebase -- itostring handles ints but
-     * doesn't zero-pad, so do the 4-char hex word ourselves. */
+void hexbyte(char *out, uint8_t v){
     static const char DIGITS[] = "0123456789ABCDEF";
     out[0] = DIGITS[(v >> 4) & 0xF];
     out[1] = DIGITS[v & 0xF];
 }
 
-static void hexword(char *out, uint16_t v){
+void hexword(char *out, uint16_t v){
     hexbyte(out, (uint8_t)(v >> 8));
     hexbyte(out + 2, (uint8_t)(v & 0xFF));
 }
 
-static void formatGridRow(char *out, const uint16_t *words, int row){
-    /* "00:FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF" -- the 2-char
-     * row label is the address of the first word in that row, in
-     * hex, so the user can map any cell back to its EEPROM index. */
+void formatGridRow(char *out, const uint16_t *words, int row){
     int col;
-    hexbyte(out, (uint8_t)(row * GRID_COLS));
+    hexbyte(out, (uint8_t)(row * EE_GRID_COLS));
     out[2] = ':';
-    for(col = 0; col < GRID_COLS; col++){
+    for(col = 0; col < EE_GRID_COLS; col++){
         out[3 + col * 5] = ' ';
-        hexword(out + 4 + col * 5, words[row * GRID_COLS + col]);
+        hexword(out + 4 + col * 5, words[row * EE_GRID_COLS + col]);
     }
-    out[3 + GRID_COLS * 5] = '\0';
+    out[3 + EE_GRID_COLS * 5] = '\0';
 }
 
-static void formatCursorLine(char *out, int cursor, uint16_t orig, uint16_t cur){
-    /* Template offsets (0-based):
-     *   "ADDR: 0x00  ORIG: 0000  CUR: 0000"
-     *    0123456789012345678901234567890123
-     *            ^^         ^^^^         ^^^^
-     *            8,9        18..21       29..32
-     * The CUR field starts at column 29 -- column 28 is the space
-     * after "CUR:". Writing the hex word at 28 (the original code)
-     * stomped on that space and left the trailing '0' of the
-     * template intact, producing "CUR:FFFF0" on screen. */
+void formatCursorLine(char *out, int cursor, uint16_t orig, uint16_t cur){
     int i;
     static const char tmpl[] = "ADDR: 0x00  ORIG: 0000  CUR: 0000";
     for(i = 0; tmpl[i] != '\0'; i++){
@@ -305,7 +290,7 @@ void EepromTest(void){
      * right now (refreshed after every write-test pass and on B). */
     uint16_t original[EE_NWORDS];
     uint16_t current[EE_NWORDS];
-    char rowBuf[3 + GRID_COLS * 5 + 1];
+    char rowBuf[3 + EE_GRID_COLS * 5 + 1];
     char cursorBuf[40];
     /* Sized for the longest line we publish: the exit-time restore
      * failure warning ("WARN: restore failed at 0xNN -- check save
@@ -315,7 +300,7 @@ void EepromTest(void){
     textBox *titleTb;
     textBox *statusTb;
     textBox *cursorTb;
-    textBox *gridTb[GRID_ROWS];
+    textBox *gridTb[EE_GRID_ROWS];
     textBox *helpTb1;
     textBox *helpTb2;
 
@@ -351,7 +336,7 @@ void EepromTest(void){
     cursorTb = newTextBox("ADDR: 0x00  ORIG: 0000  CUR: 0000", 320, 9, mainFont, 0,
                           settings->d, 0, 40 + settings->PALOffset, 13, 1);
 
-    for(row = 0; row < GRID_ROWS; row++){
+    for(row = 0; row < EE_GRID_ROWS; row++){
         gridTb[row] = newTextBox("00: 0000 0000 0000 0000 0000 0000 0000 0000", 320, 9, mainFont, 0,
                                  settings->d, GRID_X, GRID_Y + row * GRID_ROW_H + settings->PALOffset, 13, 1);
     }
@@ -393,12 +378,12 @@ void EepromTest(void){
         }
         if((settings->joy1 & JOYPAD_DOWN) && settings->controllerLock == 0){
             settings->controllerLock = 1;
-            cursor = (cursor + GRID_COLS) % EE_NWORDS;
+            cursor = (cursor + EE_GRID_COLS) % EE_NWORDS;
             needRedraw = 1;
         }
         if((settings->joy1 & JOYPAD_UP) && settings->controllerLock == 0){
             settings->controllerLock = 1;
-            cursor = (cursor + EE_NWORDS - GRID_COLS) % EE_NWORDS;
+            cursor = (cursor + EE_NWORDS - EE_GRID_COLS) % EE_NWORDS;
             needRedraw = 1;
         }
 
@@ -533,13 +518,13 @@ void EepromTest(void){
             formatCursorLine(cursorBuf, cursor, original[cursor], current[cursor]);
             updateLine(settings, mainFont, cursorTb, cursorBuf, 999999, 999999, WHITE);
 
-            for(row = 0; row < GRID_ROWS; row++){
+            for(row = 0; row < EE_GRID_ROWS; row++){
                 /* Highlight the row that contains the cursor in red so
                  * the active selection is obvious without having to
                  * underline a single 4-char hex word (which would need
                  * a sub-textBox). The selected cell within that row
                  * is the one whose address matches the cursor info line. */
-                uint16_t color = (cursor / GRID_COLS == row) ? RED : WHITE;
+                uint16_t color = (cursor / EE_GRID_COLS == row) ? RED : WHITE;
                 formatGridRow(rowBuf, current, row);
                 updateLine(settings, mainFont, gridTb[row], rowBuf, 999999, 999999, color);
             }
@@ -621,7 +606,7 @@ void EepromTest(void){
     hide_or_show_display_layer_range(settings->d, 0, 3, 15);
     helpTb2  = freeTextBox(helpTb2);
     helpTb1  = freeTextBox(helpTb1);
-    for(row = GRID_ROWS - 1; row >= 0; row--){
+    for(row = EE_GRID_ROWS - 1; row >= 0; row--){
         gridTb[row] = freeTextBox(gridTb[row]);
     }
     cursorTb = freeTextBox(cursorTb);

--- a/eeprom_test.c
+++ b/eeprom_test.c
@@ -57,8 +57,8 @@
 #define EE_DI_REG (*(volatile uint8_t *)0xF14801)
 #define EE_CS_REG (*(volatile uint8_t *)0xF15001)
 
-/* 93C46 organisation: 64 words of 16 bits each. */
-#define EE_NWORDS 64
+/* EE_NWORDS now lives in eeprom_test.h so the Memory Track test can
+ * share it without duplicating the definition. */
 
 /* WRITE poll budget. VJ returns ready immediately; real hardware
  * needs ~10 ms which at 13.3 MHz / typical loop overhead lands well
@@ -122,7 +122,7 @@ static int ee_wait_ready(void){
     return 0;
 }
 
-static uint16_t eeprom_read_word_drv(uint8_t addr){
+uint16_t eeprom_read_word_drv(uint8_t addr){
     /* READ: start(1) + op(10) + addr(6) -> 16 data bits */
     ee_cs();
     ee_send_bit(1);
@@ -132,7 +132,7 @@ static uint16_t eeprom_read_word_drv(uint8_t addr){
     return ee_recv_word();
 }
 
-static void eeprom_ewen_drv(void){
+void eeprom_ewen_drv(void){
     /* EWEN: start(1) + op(00) + sub(11xxxx) -- 4 trailing bits are
      * "don't care" but we send 0s to be predictable. */
     ee_cs();
@@ -147,7 +147,7 @@ static void eeprom_ewen_drv(void){
     ee_send_bit(0);
 }
 
-static void eeprom_ewds_drv(void){
+void eeprom_ewds_drv(void){
     /* EWDS: start(1) + op(00) + sub(00xxxx) -- the chip's reset
      * default; we send it explicitly when the test is done so we
      * don't leave the EEPROM "open for writes" after exit. */
@@ -163,7 +163,7 @@ static void eeprom_ewds_drv(void){
     ee_send_bit(0);
 }
 
-static int eeprom_write_word_drv(uint8_t addr, uint16_t data){
+int eeprom_write_word_drv(uint8_t addr, uint16_t data){
     /* WRITE: start(1) + op(01) + addr(6) + data(16) -> poll DO until idle.
      *
      * Returns the result of ee_wait_ready() so callers can detect a

--- a/eeprom_test.h
+++ b/eeprom_test.h
@@ -37,6 +37,16 @@
  * on exit, so running it never costs the user their real save data.
  * --------------------------------------------------------------------------- */
 
+/* 93C46 organisation: 64 words of 16 bits each. */
+#define EE_NWORDS 64
+
+/* Low-level 93C46 command wrappers shared by the cart EEPROM test and
+ * the Memory Track test (same Jerry bus, different physical chip). */
+uint16_t eeprom_read_word_drv(uint8_t addr);
+int eeprom_write_word_drv(uint8_t addr, uint16_t data);
+void eeprom_ewen_drv(void);
+void eeprom_ewds_drv(void);
+
 void EepromTest(void);
 
 #endif

--- a/eeprom_test.h
+++ b/eeprom_test.h
@@ -38,7 +38,9 @@
  * --------------------------------------------------------------------------- */
 
 /* 93C46 organisation: 64 words of 16 bits each. */
-#define EE_NWORDS 64
+#define EE_NWORDS   64
+#define EE_GRID_COLS 8
+#define EE_GRID_ROWS 8
 
 /* Low-level 93C46 command wrappers shared by the cart EEPROM test and
  * the Memory Track test (same Jerry bus, different physical chip). */
@@ -46,6 +48,13 @@ uint16_t eeprom_read_word_drv(uint8_t addr);
 int eeprom_write_word_drv(uint8_t addr, uint16_t data);
 void eeprom_ewen_drv(void);
 void eeprom_ewds_drv(void);
+
+/* Hex formatting helpers shared between the EEPROM test and Memory
+ * Track test so both screens produce identical grid layouts. */
+void hexbyte(char *out, uint8_t v);
+void hexword(char *out, uint16_t v);
+void formatGridRow(char *out, const uint16_t *words, int row);
+void formatCursorLine(char *out, int cursor, uint16_t orig, uint16_t cur);
 
 void EepromTest(void);
 

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -2161,11 +2161,11 @@ void MemoryTrackTest(void){
     }
 
     titleTb = newTextBox("MEMORY TRACK TEST (93C46 64x16)      ", 320, 9, mainFont, 0,
-                          settings->d, 0, 8 + settings->PALOffset, 13, 1);
+                          settings->d, 0, 8 + settings->PALOffset, 12, 1);
     updateLine(settings, mainFont, titleTb, NULL, 999999, 999999, GREEN);
 
     cdStatusTb = newTextBox("CD: NOT DETECTED (testing cart EEPROM)", 320, 9, mainFont, 0,
-                             settings->d, 0, 22 + settings->PALOffset, 13, 1);
+                             settings->d, 0, 22 + settings->PALOffset, 12, 1);
     if(cdDetected){
         updateLine(settings, mainFont, cdStatusTb, "CD: DETECTED (testing Memory Track)  ", 999999, 999999, GREEN);
     } else {
@@ -2173,26 +2173,28 @@ void MemoryTrackTest(void){
     }
 
     statusTb = newTextBox("WARN: restore failed at 0xFF -- check save data", 320, 9, mainFont, 0,
-                          settings->d, 0, 36 + settings->PALOffset, 13, 1);
+                          settings->d, 0, 36 + settings->PALOffset, 12, 1);
     updateLine(settings, mainFont, statusTb, "STATUS: idle (press A or X)", 999999, 999999, GREY);
 
     cursorTb = newTextBox("ADDR: 0x00  ORIG: 0000  CUR: 0000", 320, 9, mainFont, 0,
-                          settings->d, 0, 50 + settings->PALOffset, 13, 1);
+                          settings->d, 0, 50 + settings->PALOffset, 12, 1);
 
     for(row = 0; row < EE_GRID_ROWS; row++){
         gridTb[row] = newTextBox("00: 0000 0000 0000 0000 0000 0000 0000 0000", 320, 9, mainFont, 0,
-                                 settings->d, 0, 68 + row * 14 + settings->PALOffset, 13, 1);
+                                 settings->d, 0, 68 + row * 14 + settings->PALOffset, 12, 1);
     }
 
     helpTb1 = newTextBox("D-PAD move  A walk-1s  X addr-as-data",
                          320, 9, mainFont, 0,
-                         settings->d, 0, 184 + settings->PALOffset, 13, 1);
+                         settings->d, 0, 184 + settings->PALOffset, 12, 1);
     updateLine(settings, mainFont, helpTb1, NULL, 999999, 999999, GREY);
 
     helpTb2 = newTextBox("B re-read  Y erase  DOWN+OPT help  OPT exit",
                          320, 9, mainFont, 0,
-                         settings->d, 0, 196 + settings->PALOffset, 13, 1);
+                         settings->d, 0, 196 + settings->PALOffset, 12, 1);
     updateLine(settings, mainFont, helpTb2, NULL, 999999, 999999, GREY);
+
+    hide_or_show_display_layer_range(settings->d, 1, 12, 12);
 
     while(!exit_test){
         read_joypad_state(settings->j_state);
@@ -2388,6 +2390,7 @@ void MemoryTrackTest(void){
         }
     }
 
+    hide_or_show_display_layer_range(settings->d, 0, 12, 12);
     helpTb2    = freeTextBox(helpTb2);
     helpTb1    = freeTextBox(helpTb1);
     for(row = EE_GRID_ROWS - 1; row >= 0; row--){

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -2028,7 +2028,7 @@ void JaguarCDTest(void){
     textBox *hTb  = newTextBox("$800002 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 156 + settings->PALOffset, 13, 1);
     textBox *biosTb = newTextBox("BIOS    : NOT FOUND       ", 256, 9, mainFont, 0, settings->d, 48, 170 + settings->PALOffset, 13, 1);
     textBox *noteTb = newTextBox("LIVE/frm: hex refresh  0000+FFFF=open", 256, 9, mainFont, 0, settings->d, 16, 186 + settings->PALOffset, 13, 1);
-    textBox *helpTb = newTextBox("A: Memory Track  DOWN+OPT: help  OPT: exit", 320, 9, mainFont, 0, settings->d, 0, 204 + settings->PALOffset, 13, 1);
+    textBox *helpTb = newTextBox("A: Memory Track  DOWN+OPTION: help  OPT: exit", 320, 9, mainFont, 0, settings->d, 0, 204 + settings->PALOffset, 13, 1);
     updateLine(settings, mainFont, noteTb, NULL, 999999, 999999, GREY);
     updateLine(settings, mainFont, helpTb, NULL, 999999, 999999, GREY);
     extraHighlightJagCdFooterLine(helpTb);

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -2037,7 +2037,7 @@ void JaguarCDTest(void){
     textBox *hTb  = newTextBox("$800002 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 156 + settings->PALOffset, 13, 1);
     textBox *biosTb = newTextBox("BIOS    : NOT FOUND       ", 256, 9, mainFont, 0, settings->d, 48, 170 + settings->PALOffset, 13, 1);
     textBox *noteTb = newTextBox("LIVE/frm: hex refresh  0000+FFFF=open", 256, 9, mainFont, 0, settings->d, 16, 186 + settings->PALOffset, 13, 1);
-    textBox *helpTb = newTextBox("DOWN+OPTION: help   OPTION: exit", 256, 9, mainFont, 0, settings->d, 32, 204 + settings->PALOffset, 13, 1);
+    textBox *helpTb = newTextBox("A: Memory Track  DOWN+OPT: help  OPT: exit", 320, 9, mainFont, 0, settings->d, 0, 204 + settings->PALOffset, 13, 1);
     updateLine(settings, mainFont, noteTb, NULL, 999999, 999999, GREY);
     updateLine(settings, mainFont, helpTb, NULL, 999999, 999999, GREY);
     extraHighlightJagCdFooterLine(helpTb);
@@ -2063,6 +2063,12 @@ void JaguarCDTest(void){
         if(((settings->joy1 & JOYPAD_DOWN) && (settings->joy1 & JOYPAD_OPTION)) && settings->controllerLock == 0){
             settings->controllerLock = 1;
             DrawHelp(HELP_JAGUAR_CD);
+        }
+        if((settings->joy1 & JOYPAD_A) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            hide_or_show_display_layer_range(settings->d, 0, 3, 15);
+            MemoryTrackTest();
+            hide_or_show_display_layer_range(settings->d, 1, 3, 15);
         }
         if(extraExitPressed()){
             settings->controllerLock = 1;

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -2194,8 +2194,6 @@ void MemoryTrackTest(void){
                          settings->d, 0, 196 + settings->PALOffset, 13, 1);
     updateLine(settings, mainFont, helpTb2, NULL, 999999, 999999, GREY);
 
-    hide_or_show_display_layer_range(settings->d, 1, 3, 15);
-
     while(!exit_test){
         read_joypad_state(settings->j_state);
         settings->joy1 = settings->j_state->j1;
@@ -2390,7 +2388,6 @@ void MemoryTrackTest(void){
         }
     }
 
-    hide_or_show_display_layer_range(settings->d, 0, 3, 15);
     helpTb2    = freeTextBox(helpTb2);
     helpTb1    = freeTextBox(helpTb1);
     for(row = EE_GRID_ROWS - 1; row >= 0; row--){

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -1,4 +1,5 @@
 #include "./extra_tests.h"
+#include "./eeprom_test.h"
 #include "./tests.h" /* for the C1..C9 frequency constants used by audio */
 
 /* ---------------------------------------------------------------------------
@@ -1971,30 +1972,72 @@ static void jagCdSetHex4(textBox *tb, char *buf, uint16_t v){
     for(i = 0; i < n; i++) tb->text[hexStart + (4 - n) + i] = buf[i];
 }
 
+static void mtHexByte(char *out, uint8_t v){
+    static const char D[] = "0123456789ABCDEF";
+    out[0] = D[(v >> 4) & 0xF];
+    out[1] = D[v & 0xF];
+}
+
+static void mtHexWord(char *out, uint16_t v){
+    mtHexByte(out, (uint8_t)(v >> 8));
+    mtHexByte(out + 2, (uint8_t)(v & 0xFF));
+}
+
+static void mtFormatGridRow(char *out, const uint16_t *words, int row){
+    int col;
+    mtHexByte(out, (uint8_t)(row * 8));
+    out[2] = ':';
+    for(col = 0; col < 8; col++){
+        out[3 + col * 5] = ' ';
+        mtHexWord(out + 4 + col * 5, words[row * 8 + col]);
+    }
+    out[3 + 8 * 5] = '\0';
+}
+
+static void mtFormatCursorLine(char *out, int cursor, uint16_t orig, uint16_t cur){
+    int i;
+    static const char tmpl[] = "ADDR: 0x00  ORIG: 0000  CUR: 0000";
+    for(i = 0; tmpl[i] != '\0'; i++){
+        out[i] = tmpl[i];
+    }
+    out[i] = '\0';
+    mtHexByte(out + 8, (uint8_t)(cursor & 0xFF));
+    mtHexWord(out + 18, orig);
+    mtHexWord(out + 29, cur);
+}
+
 void JaguarCDTest(void){
     int exit = 0;
     char buf[12] = "00000000\0";
     int i;
     int detected;
-    uint16_t u0, u1, u2, u3, u4;
+    int biosFound;
+    uint16_t u0, u1, u2, u3, u4, u5, u6, u7;
 
     volatile uint16_t *butch0  = (volatile uint16_t*)0xF14000;
     volatile uint16_t *butch1  = (volatile uint16_t*)0xF14002;
     volatile uint16_t *butch2  = (volatile uint16_t*)0xF14004;
-    volatile uint16_t *butch3  = (volatile uint16_t*)0xF14008;
+    volatile uint16_t *butch3  = (volatile uint16_t*)0xF14006;
+    volatile uint16_t *butch4  = (volatile uint16_t*)0xF14008;
+    volatile uint16_t *butch5  = (volatile uint16_t*)0xF1400A;
     volatile uint16_t *cdBios0 = (volatile uint16_t*)0x00800000;
+    volatile uint16_t *cdBios1 = (volatile uint16_t*)0x00800002;
 
-    textBox *titleTb = newTextBox("JAGUAR CD PROBE", 192, 9, mainFont, 0, settings->d, 80, 40, 13, 1);
+    textBox *titleTb  = newTextBox("JAGUAR CD PROBE", 192, 9, mainFont, 0, settings->d, 80, 24 + settings->PALOffset, 13, 1);
     updateLine(settings, mainFont, titleTb, NULL, 999999, 999999, GREEN);
 
-    textBox *statusTb = newTextBox("STATUS  : NOT DETECTED  ", 256, 9, mainFont, 0, settings->d, 48, 60, 13, 1);
-    textBox *aTb = newTextBox("$F14000 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 80, 13, 1);
-    textBox *bTb = newTextBox("$F14002 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 96, 13, 1);
-    textBox *cTb = newTextBox("$F14004 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 112, 13, 1);
-    textBox *dTb = newTextBox("$F14008 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 128, 13, 1);
-    textBox *eTb = newTextBox("$800000 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 144, 13, 1);
-    textBox *noteTb = newTextBox("LIVE/frm: hex refresh  0000+FFFF=open", 256, 9, mainFont, 0, settings->d, 16, 168, 13, 1);
-    textBox *helpTb = newTextBox("DOWN+OPTION: help   OPTION: exit", 256, 9, mainFont, 0, settings->d, 32, 196, 13, 1);
+    textBox *statusTb = newTextBox("STATUS  : NOT DETECTED  ", 256, 9, mainFont, 0, settings->d, 48, 40 + settings->PALOffset, 13, 1);
+    textBox *aTb  = newTextBox("$F14000 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 58 + settings->PALOffset, 13, 1);
+    textBox *bTb  = newTextBox("$F14002 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 72 + settings->PALOffset, 13, 1);
+    textBox *cTb  = newTextBox("$F14004 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 86 + settings->PALOffset, 13, 1);
+    textBox *dTb  = newTextBox("$F14006 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 100 + settings->PALOffset, 13, 1);
+    textBox *eTb  = newTextBox("$F14008 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 114 + settings->PALOffset, 13, 1);
+    textBox *fTb  = newTextBox("$F1400A : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 128 + settings->PALOffset, 13, 1);
+    textBox *gTb  = newTextBox("$800000 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 142 + settings->PALOffset, 13, 1);
+    textBox *hTb  = newTextBox("$800002 : 0000 ", 192, 9, mainFont, 0, settings->d, 48, 156 + settings->PALOffset, 13, 1);
+    textBox *biosTb = newTextBox("BIOS    : NOT FOUND       ", 256, 9, mainFont, 0, settings->d, 48, 170 + settings->PALOffset, 13, 1);
+    textBox *noteTb = newTextBox("LIVE/frm: hex refresh  0000+FFFF=open", 256, 9, mainFont, 0, settings->d, 16, 186 + settings->PALOffset, 13, 1);
+    textBox *helpTb = newTextBox("DOWN+OPTION: help   OPTION: exit", 256, 9, mainFont, 0, settings->d, 32, 204 + settings->PALOffset, 13, 1);
     updateLine(settings, mainFont, noteTb, NULL, 999999, 999999, GREY);
     updateLine(settings, mainFont, helpTb, NULL, 999999, 999999, GREY);
     extraHighlightJagCdFooterLine(helpTb);
@@ -2008,7 +2051,10 @@ void JaguarCDTest(void){
         u1 = *butch1;
         u2 = *butch2;
         u3 = *butch3;
-        u4 = *cdBios0;
+        u4 = *butch4;
+        u5 = *butch5;
+        u6 = *cdBios0;
+        u7 = *cdBios1;
         vsync();
 
         if((settings->joy1 & 0xFFFFFF) == 0){
@@ -2029,6 +2075,12 @@ void JaguarCDTest(void){
         if(u2 != 0x0000U && u2 != 0xFFFFU) detected = 1;
         if(u3 != 0x0000U && u3 != 0xFFFFU) detected = 1;
         if(u4 != 0x0000U && u4 != 0xFFFFU) detected = 1;
+        if(u5 != 0x0000U && u5 != 0xFFFFU) detected = 1;
+
+        biosFound = 0;
+        if(u6 != 0x0000U && u6 != 0xFFFFU) biosFound = 1;
+        if(u7 != 0x0000U && u7 != 0xFFFFU) biosFound = 1;
+        if(biosFound) detected = 1;
 
         if(detected){
             {
@@ -2042,6 +2094,13 @@ void JaguarCDTest(void){
             }
         }
         updateLine(settings, mainFont, statusTb, NULL, 999999, 999999, detected ? GREEN : RED);
+
+        {
+            const char *biosStr = biosFound ? "FOUND           " : "NOT FOUND       ";
+            for(i = 0; i < 16; i++){ biosTb->text[10 + i] = biosStr[i]; }
+        }
+        updateLine(settings, mainFont, biosTb, NULL, 999999, 999999, biosFound ? GREEN : GREY);
+
         jagCdSetHex4(aTb, buf, u0);
         updateLine(settings, mainFont, aTb, NULL, 999999, 999999, WHITE);
         jagCdSetHex4(bTb, buf, u1);
@@ -2052,11 +2111,21 @@ void JaguarCDTest(void){
         updateLine(settings, mainFont, dTb, NULL, 999999, 999999, WHITE);
         jagCdSetHex4(eTb, buf, u4);
         updateLine(settings, mainFont, eTb, NULL, 999999, 999999, WHITE);
+        jagCdSetHex4(fTb, buf, u5);
+        updateLine(settings, mainFont, fTb, NULL, 999999, 999999, WHITE);
+        jagCdSetHex4(gTb, buf, u6);
+        updateLine(settings, mainFont, gTb, NULL, 999999, 999999, WHITE);
+        jagCdSetHex4(hTb, buf, u7);
+        updateLine(settings, mainFont, hTb, NULL, 999999, 999999, WHITE);
     }
 
     hide_or_show_display_layer_range(settings->d, 0, 3, 15);
     helpTb   = freeTextBox(helpTb);
     noteTb   = freeTextBox(noteTb);
+    biosTb   = freeTextBox(biosTb);
+    hTb      = freeTextBox(hTb);
+    gTb      = freeTextBox(gTb);
+    fTb      = freeTextBox(fTb);
     eTb      = freeTextBox(eTb);
     dTb      = freeTextBox(dTb);
     cTb      = freeTextBox(cTb);
@@ -2064,6 +2133,289 @@ void JaguarCDTest(void){
     aTb      = freeTextBox(aTb);
     statusTb = freeTextBox(statusTb);
     titleTb  = freeTextBox(titleTb);
+}
+
+void MemoryTrackTest(void){
+    int exit_test = 0;
+    int cursor = 0;
+    int needRedraw = 1;
+    int totalErrors = 0;
+    int lastTestRan = 0;
+    int row, i;
+    int cdDetected;
+    uint16_t original[EE_NWORDS];
+    uint16_t current[EE_NWORDS];
+    char rowBuf[3 + 8 * 5 + 1];
+    char cursorBuf[40];
+    char statusBuf[64];
+    textBox *titleTb;
+    textBox *cdStatusTb;
+    textBox *statusTb;
+    textBox *cursorTb;
+    textBox *gridTb[8];
+    textBox *helpTb1;
+    textBox *helpTb2;
+
+    {
+        volatile uint16_t *b0 = (volatile uint16_t*)0xF14000;
+        volatile uint16_t *b1 = (volatile uint16_t*)0xF14002;
+        volatile uint16_t *b2 = (volatile uint16_t*)0xF14004;
+        volatile uint16_t *b3 = (volatile uint16_t*)0xF14008;
+        volatile uint16_t *cb = (volatile uint16_t*)0x00800000;
+        uint16_t v0 = *b0, v1 = *b1, v2 = *b2, v3 = *b3, v4 = *cb;
+        cdDetected = 0;
+        if(v0 != 0x0000U && v0 != 0xFFFFU) cdDetected = 1;
+        if(v1 != 0x0000U && v1 != 0xFFFFU) cdDetected = 1;
+        if(v2 != 0x0000U && v2 != 0xFFFFU) cdDetected = 1;
+        if(v3 != 0x0000U && v3 != 0xFFFFU) cdDetected = 1;
+        if(v4 != 0x0000U && v4 != 0xFFFFU) cdDetected = 1;
+    }
+
+    for(i = 0; i < EE_NWORDS; i++){
+        original[i] = eeprom_read_word_drv((uint8_t)i);
+        current[i] = original[i];
+    }
+
+    titleTb = newTextBox("MEMORY TRACK TEST (93C46 64x16)      ", 320, 9, mainFont, 0,
+                          settings->d, 0, 8 + settings->PALOffset, 13, 1);
+    updateLine(settings, mainFont, titleTb, NULL, 999999, 999999, GREEN);
+
+    cdStatusTb = newTextBox("CD: NOT DETECTED (testing cart EEPROM)", 320, 9, mainFont, 0,
+                             settings->d, 0, 22 + settings->PALOffset, 13, 1);
+    if(cdDetected){
+        updateLine(settings, mainFont, cdStatusTb, "CD: DETECTED (testing Memory Track)  ", 999999, 999999, GREEN);
+    } else {
+        updateLine(settings, mainFont, cdStatusTb, NULL, 999999, 999999, RED);
+    }
+
+    statusTb = newTextBox("WARN: restore failed at 0xFF -- check save data", 320, 9, mainFont, 0,
+                          settings->d, 0, 36 + settings->PALOffset, 13, 1);
+    updateLine(settings, mainFont, statusTb, "STATUS: idle (press A or X)", 999999, 999999, GREY);
+
+    cursorTb = newTextBox("ADDR: 0x00  ORIG: 0000  CUR: 0000", 320, 9, mainFont, 0,
+                          settings->d, 0, 50 + settings->PALOffset, 13, 1);
+
+    for(row = 0; row < 8; row++){
+        gridTb[row] = newTextBox("00: 0000 0000 0000 0000 0000 0000 0000 0000", 320, 9, mainFont, 0,
+                                 settings->d, 0, 68 + row * 14 + settings->PALOffset, 13, 1);
+    }
+
+    helpTb1 = newTextBox("D-PAD move  A walk-1s  X addr-as-data",
+                         320, 9, mainFont, 0,
+                         settings->d, 0, 184 + settings->PALOffset, 13, 1);
+    updateLine(settings, mainFont, helpTb1, NULL, 999999, 999999, GREY);
+
+    helpTb2 = newTextBox("B re-read  Y erase  DOWN+OPT help  OPT exit",
+                         320, 9, mainFont, 0,
+                         settings->d, 0, 196 + settings->PALOffset, 13, 1);
+    updateLine(settings, mainFont, helpTb2, NULL, 999999, 999999, GREY);
+
+    hide_or_show_display_layer_range(settings->d, 1, 3, 15);
+
+    while(!exit_test){
+        read_joypad_state(settings->j_state);
+        settings->joy1 = settings->j_state->j1;
+        vsync();
+
+        if((settings->joy1 & 0xFFFFFF) == 0){
+            settings->controllerLock = 0;
+        }
+
+        if(((settings->joy1 & JOYPAD_DOWN) && (settings->joy1 & JOYPAD_OPTION)) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            DrawHelp(HELP_MEMORY_TRACK);
+        }
+
+        if((settings->joy1 & JOYPAD_RIGHT) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            cursor = (cursor + 1) % EE_NWORDS;
+            needRedraw = 1;
+        }
+        if((settings->joy1 & JOYPAD_LEFT) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            cursor = (cursor + EE_NWORDS - 1) % EE_NWORDS;
+            needRedraw = 1;
+        }
+        if((settings->joy1 & JOYPAD_DOWN) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            cursor = (cursor + 8) % EE_NWORDS;
+            needRedraw = 1;
+        }
+        if((settings->joy1 & JOYPAD_UP) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            cursor = (cursor + EE_NWORDS - 8) % EE_NWORDS;
+            needRedraw = 1;
+        }
+
+        if((settings->joy1 & JOYPAD_A) && settings->controllerLock == 0){
+            uint16_t pattern[EE_NWORDS];
+            int errs;
+            settings->controllerLock = 1;
+            for(i = 0; i < EE_NWORDS; i++){
+                pattern[i] = (uint16_t)(1u << (i % 16));
+            }
+            eeprom_ewen_drv();
+            errs = 0;
+            for(i = 0; i < EE_NWORDS; i++){
+                (void)eeprom_write_word_drv((uint8_t)i, pattern[i]);
+            }
+            for(i = 0; i < EE_NWORDS; i++){
+                if(eeprom_read_word_drv((uint8_t)i) != pattern[i]) errs++;
+            }
+            totalErrors += errs;
+            lastTestRan = 1;
+            for(i = 0; i < EE_NWORDS; i++){
+                current[i] = eeprom_read_word_drv((uint8_t)i);
+            }
+            needRedraw = 1;
+        }
+
+        if((settings->joy1 & JOYPAD_X) && settings->controllerLock == 0){
+            uint16_t pattern[EE_NWORDS];
+            int errs;
+            settings->controllerLock = 1;
+            for(i = 0; i < EE_NWORDS; i++){
+                pattern[i] = (uint16_t)(((uint16_t)i << 8) | ((~(uint16_t)i) & 0xFF));
+            }
+            eeprom_ewen_drv();
+            errs = 0;
+            for(i = 0; i < EE_NWORDS; i++){
+                (void)eeprom_write_word_drv((uint8_t)i, pattern[i]);
+            }
+            for(i = 0; i < EE_NWORDS; i++){
+                if(eeprom_read_word_drv((uint8_t)i) != pattern[i]) errs++;
+            }
+            totalErrors += errs;
+            lastTestRan = 2;
+            for(i = 0; i < EE_NWORDS; i++){
+                current[i] = eeprom_read_word_drv((uint8_t)i);
+            }
+            needRedraw = 1;
+        }
+
+        if((settings->joy1 & JOYPAD_B) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            for(i = 0; i < EE_NWORDS; i++){
+                current[i] = eeprom_read_word_drv((uint8_t)i);
+            }
+            needRedraw = 1;
+        }
+
+        if((settings->joy1 & JOYPAD_Y) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            eeprom_ewen_drv();
+            eeprom_write_word_drv((uint8_t)cursor, 0xFFFF);
+            current[cursor] = eeprom_read_word_drv((uint8_t)cursor);
+            needRedraw = 1;
+        }
+
+        if((settings->joy1 & JOYPAD_OPTION) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            exit_test = 1;
+        }
+
+        if(needRedraw){
+            const char *label;
+            const char *prefix;
+            int n, k;
+            uint16_t statusColor;
+
+            needRedraw = 0;
+
+            label = "idle (press A or X)";
+            if(lastTestRan == 1) label = "WALKING-1S complete";
+            else if(lastTestRan == 2) label = "ADDR-AS-DATA complete";
+
+            n = 0;
+            prefix = "STATUS: ";
+            while(prefix[n] != '\0'){ statusBuf[n] = prefix[n]; n++; }
+            k = 0;
+            while(label[k] != '\0' && n < (int)sizeof(statusBuf) - 12){
+                statusBuf[n++] = label[k++];
+            }
+            if(lastTestRan){
+                const char *errLabel = "  ERRORS: ";
+                int j = 0;
+                int displayErrors = totalErrors;
+                while(errLabel[j] != '\0' && n < (int)sizeof(statusBuf) - 5){
+                    statusBuf[n++] = errLabel[j++];
+                }
+                if(displayErrors > 999) displayErrors = 999;
+                if(displayErrors >= 100) statusBuf[n++] = (char)('0' + (displayErrors / 100));
+                if(displayErrors >= 10) statusBuf[n++] = (char)('0' + ((displayErrors / 10) % 10));
+                statusBuf[n++] = (char)('0' + (displayErrors % 10));
+            }
+            statusBuf[n] = '\0';
+            statusColor = GREY;
+            if(lastTestRan) statusColor = (totalErrors == 0) ? GREEN : RED;
+            updateLine(settings, mainFont, statusTb, statusBuf, 999999, 999999, statusColor);
+
+            mtFormatCursorLine(cursorBuf, cursor, original[cursor], current[cursor]);
+            updateLine(settings, mainFont, cursorTb, cursorBuf, 999999, 999999, WHITE);
+
+            for(row = 0; row < 8; row++){
+                uint16_t color = (cursor / 8 == row) ? RED : WHITE;
+                mtFormatGridRow(rowBuf, current, row);
+                updateLine(settings, mainFont, gridTb[row], rowBuf, 999999, 999999, color);
+            }
+        }
+    }
+
+    {
+        int restoreFailed = 0;
+        int badAddr = -1;
+        int attempts;
+        uint16_t verify = 0;
+
+        eeprom_ewen_drv();
+        for(i = 0; i < EE_NWORDS; i++){
+            if(current[i] == original[i]) continue;
+            verify = current[i];
+            for(attempts = 0; attempts < 3; attempts++){
+                (void)eeprom_write_word_drv((uint8_t)i, original[i]);
+                verify = eeprom_read_word_drv((uint8_t)i);
+                if(verify == original[i]){
+                    current[i] = verify;
+                    break;
+                }
+            }
+            if(verify != original[i] && !restoreFailed){
+                restoreFailed = 1;
+                badAddr = i;
+            }
+        }
+        eeprom_ewds_drv();
+
+        if(restoreFailed){
+            const char *warn = "WARN: restore failed at 0x";
+            const char *tail = " -- check save data";
+            int n = 0;
+            int t = 0;
+            int hold;
+
+            while(warn[n] != '\0'){ statusBuf[n] = warn[n]; n++; }
+            mtHexByte(statusBuf + n, (uint8_t)(badAddr & 0xFF));
+            n += 2;
+            while(tail[t] != '\0'){ statusBuf[n++] = tail[t++]; }
+            statusBuf[n] = '\0';
+            updateLine(settings, mainFont, statusTb, statusBuf, 999999, 999999, RED);
+
+            for(hold = 0; hold < 120; hold++){
+                vsync();
+            }
+        }
+    }
+
+    hide_or_show_display_layer_range(settings->d, 0, 3, 15);
+    helpTb2    = freeTextBox(helpTb2);
+    helpTb1    = freeTextBox(helpTb1);
+    for(row = 7; row >= 0; row--){
+        gridTb[row] = freeTextBox(gridTb[row]);
+    }
+    cursorTb   = freeTextBox(cursorTb);
+    statusTb   = freeTextBox(statusTb);
+    cdStatusTb = freeTextBox(cdStatusTb);
+    titleTb    = freeTextBox(titleTb);
 }
 
 /* ---------------------------------------------------------------------------

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -1972,38 +1972,29 @@ static void jagCdSetHex4(textBox *tb, char *buf, uint16_t v){
     for(i = 0; i < n; i++) tb->text[hexStart + (4 - n) + i] = buf[i];
 }
 
-static void mtHexByte(char *out, uint8_t v){
-    static const char D[] = "0123456789ABCDEF";
-    out[0] = D[(v >> 4) & 0xF];
-    out[1] = D[v & 0xF];
-}
+/* Shared CD-detection heuristic: probes all 6 Butch registers
+ * ($F14000-$F1400A) and both CD BIOS window words ($800000-$800002).
+ * Returns 1 if any register reads non-open-bus, 0 otherwise. */
+static int jagCdProbeDetect(void){
+    volatile uint16_t *addrs[8];
+    uint16_t vals[8];
+    int i, det;
 
-static void mtHexWord(char *out, uint16_t v){
-    mtHexByte(out, (uint8_t)(v >> 8));
-    mtHexByte(out + 2, (uint8_t)(v & 0xFF));
-}
+    addrs[0] = (volatile uint16_t*)0xF14000;
+    addrs[1] = (volatile uint16_t*)0xF14002;
+    addrs[2] = (volatile uint16_t*)0xF14004;
+    addrs[3] = (volatile uint16_t*)0xF14006;
+    addrs[4] = (volatile uint16_t*)0xF14008;
+    addrs[5] = (volatile uint16_t*)0xF1400A;
+    addrs[6] = (volatile uint16_t*)0x00800000;
+    addrs[7] = (volatile uint16_t*)0x00800002;
 
-static void mtFormatGridRow(char *out, const uint16_t *words, int row){
-    int col;
-    mtHexByte(out, (uint8_t)(row * 8));
-    out[2] = ':';
-    for(col = 0; col < 8; col++){
-        out[3 + col * 5] = ' ';
-        mtHexWord(out + 4 + col * 5, words[row * 8 + col]);
+    det = 0;
+    for(i = 0; i < 8; i++){
+        vals[i] = *addrs[i];
+        if(vals[i] != 0x0000U && vals[i] != 0xFFFFU) det = 1;
     }
-    out[3 + 8 * 5] = '\0';
-}
-
-static void mtFormatCursorLine(char *out, int cursor, uint16_t orig, uint16_t cur){
-    int i;
-    static const char tmpl[] = "ADDR: 0x00  ORIG: 0000  CUR: 0000";
-    for(i = 0; tmpl[i] != '\0'; i++){
-        out[i] = tmpl[i];
-    }
-    out[i] = '\0';
-    mtHexByte(out + 8, (uint8_t)(cursor & 0xFF));
-    mtHexWord(out + 18, orig);
-    mtHexWord(out + 29, cur);
+    return det;
 }
 
 void JaguarCDTest(void){
@@ -2151,31 +2142,18 @@ void MemoryTrackTest(void){
     int cdDetected;
     uint16_t original[EE_NWORDS];
     uint16_t current[EE_NWORDS];
-    char rowBuf[3 + 8 * 5 + 1];
+    char rowBuf[3 + EE_GRID_COLS * 5 + 1];
     char cursorBuf[40];
     char statusBuf[64];
     textBox *titleTb;
     textBox *cdStatusTb;
     textBox *statusTb;
     textBox *cursorTb;
-    textBox *gridTb[8];
+    textBox *gridTb[EE_GRID_ROWS];
     textBox *helpTb1;
     textBox *helpTb2;
 
-    {
-        volatile uint16_t *b0 = (volatile uint16_t*)0xF14000;
-        volatile uint16_t *b1 = (volatile uint16_t*)0xF14002;
-        volatile uint16_t *b2 = (volatile uint16_t*)0xF14004;
-        volatile uint16_t *b3 = (volatile uint16_t*)0xF14008;
-        volatile uint16_t *cb = (volatile uint16_t*)0x00800000;
-        uint16_t v0 = *b0, v1 = *b1, v2 = *b2, v3 = *b3, v4 = *cb;
-        cdDetected = 0;
-        if(v0 != 0x0000U && v0 != 0xFFFFU) cdDetected = 1;
-        if(v1 != 0x0000U && v1 != 0xFFFFU) cdDetected = 1;
-        if(v2 != 0x0000U && v2 != 0xFFFFU) cdDetected = 1;
-        if(v3 != 0x0000U && v3 != 0xFFFFU) cdDetected = 1;
-        if(v4 != 0x0000U && v4 != 0xFFFFU) cdDetected = 1;
-    }
+    cdDetected = jagCdProbeDetect();
 
     for(i = 0; i < EE_NWORDS; i++){
         original[i] = eeprom_read_word_drv((uint8_t)i);
@@ -2201,7 +2179,7 @@ void MemoryTrackTest(void){
     cursorTb = newTextBox("ADDR: 0x00  ORIG: 0000  CUR: 0000", 320, 9, mainFont, 0,
                           settings->d, 0, 50 + settings->PALOffset, 13, 1);
 
-    for(row = 0; row < 8; row++){
+    for(row = 0; row < EE_GRID_ROWS; row++){
         gridTb[row] = newTextBox("00: 0000 0000 0000 0000 0000 0000 0000 0000", 320, 9, mainFont, 0,
                                  settings->d, 0, 68 + row * 14 + settings->PALOffset, 13, 1);
     }
@@ -2244,12 +2222,12 @@ void MemoryTrackTest(void){
         }
         if((settings->joy1 & JOYPAD_DOWN) && settings->controllerLock == 0){
             settings->controllerLock = 1;
-            cursor = (cursor + 8) % EE_NWORDS;
+            cursor = (cursor + EE_GRID_COLS) % EE_NWORDS;
             needRedraw = 1;
         }
         if((settings->joy1 & JOYPAD_UP) && settings->controllerLock == 0){
             settings->controllerLock = 1;
-            cursor = (cursor + EE_NWORDS - 8) % EE_NWORDS;
+            cursor = (cursor + EE_NWORDS - EE_GRID_COLS) % EE_NWORDS;
             needRedraw = 1;
         }
 
@@ -2356,12 +2334,12 @@ void MemoryTrackTest(void){
             if(lastTestRan) statusColor = (totalErrors == 0) ? GREEN : RED;
             updateLine(settings, mainFont, statusTb, statusBuf, 999999, 999999, statusColor);
 
-            mtFormatCursorLine(cursorBuf, cursor, original[cursor], current[cursor]);
+            formatCursorLine(cursorBuf, cursor, original[cursor], current[cursor]);
             updateLine(settings, mainFont, cursorTb, cursorBuf, 999999, 999999, WHITE);
 
-            for(row = 0; row < 8; row++){
-                uint16_t color = (cursor / 8 == row) ? RED : WHITE;
-                mtFormatGridRow(rowBuf, current, row);
+            for(row = 0; row < EE_GRID_ROWS; row++){
+                uint16_t color = (cursor / EE_GRID_COLS == row) ? RED : WHITE;
+                formatGridRow(rowBuf, current, row);
                 updateLine(settings, mainFont, gridTb[row], rowBuf, 999999, 999999, color);
             }
         }
@@ -2400,7 +2378,7 @@ void MemoryTrackTest(void){
             int hold;
 
             while(warn[n] != '\0'){ statusBuf[n] = warn[n]; n++; }
-            mtHexByte(statusBuf + n, (uint8_t)(badAddr & 0xFF));
+            hexbyte(statusBuf + n, (uint8_t)(badAddr & 0xFF));
             n += 2;
             while(tail[t] != '\0'){ statusBuf[n++] = tail[t++]; }
             statusBuf[n] = '\0';
@@ -2415,7 +2393,7 @@ void MemoryTrackTest(void){
     hide_or_show_display_layer_range(settings->d, 0, 3, 15);
     helpTb2    = freeTextBox(helpTb2);
     helpTb1    = freeTextBox(helpTb1);
-    for(row = 7; row >= 0; row--){
+    for(row = EE_GRID_ROWS - 1; row >= 0; row--){
         gridTb[row] = freeTextBox(gridTb[row]);
     }
     cursorTb   = freeTextBox(cursorTb);

--- a/extra_tests.h
+++ b/extra_tests.h
@@ -59,6 +59,7 @@ void ChannelSeparationTest(void);
 /* Hardware tests */
 void HardwareInfo(void);
 void JaguarCDTest(void);
+void MemoryTrackTest(void);
 void ResolutionTest(void);
 void ProControllerTest(void);
 void RotaryControllerTest(void);

--- a/help.c
+++ b/help.c
@@ -639,7 +639,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "JAGUAR CD PROBE", 999999, 999999, GREEN);
 
-                            updateLine(settings, mainFont, helpTextBox, "Probes 16-bit words in the Butch (CD) ASIC ($F14000-$F1400A) and the CD boot ROM window ($800000-$800002). On a base Jaguar these read 0x0000 or 0xFFFF (open bus).^If any word returns a different value the heuristic reports DETECTED. The BIOS line shows FOUND when the CD boot ROM window contains non-open-bus data.^Values refresh every frame for real-time monitoring.^^DOWN+OPTION: this help.   OPTION: exit", 999999, 999999, WHITE);
+                            updateLine(settings, mainFont, helpTextBox, "Probes 16-bit words in the Butch (CD) ASIC ($F14000-$F1400A) and the CD boot ROM window ($800000-$800002). On a base Jaguar these read 0x0000 or 0xFFFF (open bus).^If any word returns a different value the heuristic reports DETECTED. The BIOS line shows FOUND when the CD boot ROM window contains non-open-bus data.^Values refresh every frame for real-time monitoring.^^A: Memory Track EEPROM test^DOWN+OPTION: this help   OPTION: exit", 999999, 999999, WHITE);
                             highlightHelpPhrase(helpTextBox, "DOWN+OPTION");
                         break;
                     }

--- a/help.c
+++ b/help.c
@@ -108,6 +108,7 @@ void DrawHelp(int option){
         case HELP_PINK_NOISE:
         case HELP_CHANNEL_SEP:
         case HELP_JAGUAR_CD:
+        case HELP_MEMORY_TRACK:
             totalPages = 1;
         break;
 
@@ -638,7 +639,21 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "JAGUAR CD PROBE", 999999, 999999, GREEN);
 
-                            updateLine(settings, mainFont, helpTextBox, "Probes a handful of 16-bit words: four in the Butch (CD) ASIC at $F14000+ and the first word of the paged-in CD boot ROM window at $800000. On a base Jaguar with no CD, those often read 0x0000 or 0xFFFF (open bus).^If *any* word returns a different value, the heuristic reports DETECTED.^Values are re-read *every frame* so emulators and hardware bring-up can watch registers change in real time. This is not a full Memory-Track or disc I/O test -- use real media for that.^^DOWN+OPTION: this help.   OPTION: exit", 999999, 999999, WHITE);
+                            updateLine(settings, mainFont, helpTextBox, "Probes 16-bit words in the Butch (CD) ASIC ($F14000-$F1400A) and the CD boot ROM window ($800000-$800002). On a base Jaguar these read 0x0000 or 0xFFFF (open bus).^If any word returns a different value the heuristic reports DETECTED. The BIOS line shows FOUND when the CD boot ROM window contains non-open-bus data.^Values refresh every frame for real-time monitoring.^^DOWN+OPTION: this help.   OPTION: exit", 999999, 999999, WHITE);
+                            highlightHelpPhrase(helpTextBox, "DOWN+OPTION");
+                        break;
+                    }
+
+                break;
+
+                case HELP_MEMORY_TRACK:
+
+                    switch(page){
+
+                        case 0:
+                            updateLine(settings, mainFont, helpLineTextBox[0], "MEMORY TRACK TEST", 999999, 999999, GREEN);
+
+                            updateLine(settings, mainFont, helpTextBox, "Exercises the 93C46 serial EEPROM on the bus. On a Jaguar CD with Memory Track this is the CD unit's 128-byte save storage. Without a CD this tests the cart's own EEPROM.^The CD line shows whether CD hardware was detected. Both EEPROMs use the same Jerry bus ($F14001/$F14801/$F15001).^^A: Walking-1s   X: Address-as-data^B: Re-read   Y: Erase cell^OPTION: restore originals and exit^DOWN+OPTION: this help", 999999, 999999, WHITE);
                             highlightHelpPhrase(helpTextBox, "DOWN+OPTION");
                         break;
                     }

--- a/help.h
+++ b/help.h
@@ -54,6 +54,7 @@
 #define HELP_PINK_NOISE 38
 #define HELP_CHANNEL_SEP 39
 #define HELP_JAGUAR_CD 40
+#define HELP_MEMORY_TRACK 41
 
 extern uint8_t help;
 phrase *helpData;

--- a/main.c
+++ b/main.c
@@ -1146,9 +1146,9 @@ void HardwareMenu(){
     
     int done = 0;
     /* Max 1-based menuState value (cursor wraps between 1 and
-     * lastMenuLine). Memory Track Test is case 11, Sprite Stress
-     * Test is case 12, and "Back to Main Menu" is the final case 15. */
-    int lastMenuLine = 15;
+     * lastMenuLine). Memory Track is inside the CD Probe screen (A
+     * button), not a standalone menu entry. */
+    int lastMenuLine = 14;
     settings->menuState = 1;
     
     hide_display_layer(settings->d, 2);
@@ -1169,12 +1169,11 @@ void HardwareMenu(){
     updateLine(settings, mainFont, lineTextBox[8],  "Jaguar CD Probe",        settings->lineXOffset, setLineYPos(7), WHITE);
     updateLine(settings, mainFont, lineTextBox[9],  "Video Mode Test",        settings->lineXOffset, setLineYPos(8), WHITE);
     updateLine(settings, mainFont, lineTextBox[10], "EEPROM Test",            settings->lineXOffset, setLineYPos(9), WHITE);
-    updateLine(settings, mainFont, lineTextBox[11], "Memory Track Test",      settings->lineXOffset, setLineYPos(10), WHITE);
-    updateLine(settings, mainFont, lineTextBox[12], "Sprite Stress Test",     settings->lineXOffset, setLineYPos(11), WHITE);
+    updateLine(settings, mainFont, lineTextBox[11], "Sprite Stress Test",     settings->lineXOffset, setLineYPos(10), WHITE);
 
-    updateLine(settings, mainFont, lineTextBox[13], "Help",              settings->lineXOffset, setLineYPos(12), WHITE);
-    updateLine(settings, mainFont, lineTextBox[14], "Options",           settings->lineXOffset, setLineYPos(13), WHITE);
-    updateLine(settings, mainFont, lineTextBox[15], "Back to Main Menu", settings->lineXOffset, setLineYPos(14), WHITE);
+    updateLine(settings, mainFont, lineTextBox[12], "Help",              settings->lineXOffset, setLineYPos(11), WHITE);
+    updateLine(settings, mainFont, lineTextBox[13], "Options",           settings->lineXOffset, setLineYPos(12), WHITE);
+    updateLine(settings, mainFont, lineTextBox[14], "Back to Main Menu", settings->lineXOffset, setLineYPos(13), WHITE);
     
     updateLine(settings, mainFont, lineTextBox[0], settings->PALNTSC ? "NTSC VDP 320x240p" : "PAL VDP 320x288p", 184, 200 + settings->PALOffset, WHITE);
        
@@ -1307,22 +1306,15 @@ void HardwareMenu(){
 
                 break;
 
-                //Memory Track Test (Jaguar CD EEPROM)
-                case 11:
-
-                    MemoryTrackTest();
-
-                break;
-
                 //Sprite Stress Test (Object Processor saturation)
-                case 12:
+                case 11:
 
                     SpriteStressTest();
 
                 break;
 
                 //Help
-                case 13:
+                case 12:
 
                     hide_or_show_display_layer_range(settings->d, 0, 0, 15);
                     hide_or_show_display_layer_range(settings->d, 1, 14, 14);
@@ -1334,13 +1326,13 @@ void HardwareMenu(){
                 break;
 
                 //Options
-                case 14:
+                case 13:
 
                     OptionsMenu();
 
                 break;
 
-                case 15:
+                case 14:
 
                     done = 1;
 

--- a/main.c
+++ b/main.c
@@ -1146,12 +1146,9 @@ void HardwareMenu(){
     
     int done = 0;
     /* Max 1-based menuState value (cursor wraps between 1 and
-     * lastMenuLine). EEPROM Test is switch case 10, Sprite Stress
-     * Test is case 11, and "Back to Main Menu" is the final case 14.
-     * The other *Menu() helpers in this file use the same convention
-     * -- the legacy "counting from zero" comment was misleading since
-     * menuState is 1-based. */
-    int lastMenuLine = 14;
+     * lastMenuLine). Memory Track Test is case 11, Sprite Stress
+     * Test is case 12, and "Back to Main Menu" is the final case 15. */
+    int lastMenuLine = 15;
     settings->menuState = 1;
     
     hide_display_layer(settings->d, 2);
@@ -1172,11 +1169,12 @@ void HardwareMenu(){
     updateLine(settings, mainFont, lineTextBox[8],  "Jaguar CD Probe",        settings->lineXOffset, setLineYPos(7), WHITE);
     updateLine(settings, mainFont, lineTextBox[9],  "Video Mode Test",        settings->lineXOffset, setLineYPos(8), WHITE);
     updateLine(settings, mainFont, lineTextBox[10], "EEPROM Test",            settings->lineXOffset, setLineYPos(9), WHITE);
-    updateLine(settings, mainFont, lineTextBox[11], "Sprite Stress Test",     settings->lineXOffset, setLineYPos(10), WHITE);
+    updateLine(settings, mainFont, lineTextBox[11], "Memory Track Test",      settings->lineXOffset, setLineYPos(10), WHITE);
+    updateLine(settings, mainFont, lineTextBox[12], "Sprite Stress Test",     settings->lineXOffset, setLineYPos(11), WHITE);
 
-    updateLine(settings, mainFont, lineTextBox[12], "Help",              settings->lineXOffset, setLineYPos(11), WHITE);
-    updateLine(settings, mainFont, lineTextBox[13], "Options",           settings->lineXOffset, setLineYPos(12), WHITE);
-    updateLine(settings, mainFont, lineTextBox[14], "Back to Main Menu", settings->lineXOffset, setLineYPos(13), WHITE);
+    updateLine(settings, mainFont, lineTextBox[13], "Help",              settings->lineXOffset, setLineYPos(12), WHITE);
+    updateLine(settings, mainFont, lineTextBox[14], "Options",           settings->lineXOffset, setLineYPos(13), WHITE);
+    updateLine(settings, mainFont, lineTextBox[15], "Back to Main Menu", settings->lineXOffset, setLineYPos(14), WHITE);
     
     updateLine(settings, mainFont, lineTextBox[0], settings->PALNTSC ? "NTSC VDP 320x240p" : "PAL VDP 320x288p", 184, 200 + settings->PALOffset, WHITE);
        
@@ -1309,15 +1307,22 @@ void HardwareMenu(){
 
                 break;
 
-                //Sprite Stress Test (Object Processor saturation)
+                //Memory Track Test (Jaguar CD EEPROM)
                 case 11:
+
+                    MemoryTrackTest();
+
+                break;
+
+                //Sprite Stress Test (Object Processor saturation)
+                case 12:
 
                     SpriteStressTest();
 
                 break;
 
                 //Help
-                case 12:
+                case 13:
 
                     hide_or_show_display_layer_range(settings->d, 0, 0, 15);
                     hide_or_show_display_layer_range(settings->d, 1, 14, 14);
@@ -1327,15 +1332,15 @@ void HardwareMenu(){
                     hide_or_show_display_layer_range(settings->d, 1, 0, 15);
 
                 break;
-                    
+
                 //Options
-                case 13:
+                case 14:
 
                     OptionsMenu();
 
                 break;
 
-                case 14:
+                case 15:
 
                     done = 1;
 

--- a/main.c
+++ b/main.c
@@ -1155,10 +1155,10 @@ void HardwareMenu(){
     vsync();
     
     settings->lineXOffset = 38;
-    settings->lineYOffset = (settings->PALNTSC ? 76 : 56) + settings->PALOffset;
-    
+    settings->lineYOffset = 56 + settings->PALOffset;
+
     resetAllLines();
-        
+
     updateLine(settings, mainFont, lineTextBox[1],  "Controller Test",        settings->lineXOffset, setLineYPos(0), RED);
     updateLine(settings, mainFont, lineTextBox[2],  "Pro Controller Test",    settings->lineXOffset, setLineYPos(1), WHITE);
     updateLine(settings, mainFont, lineTextBox[3],  "Rotary Controller Test", settings->lineXOffset, setLineYPos(2), WHITE);
@@ -1171,9 +1171,9 @@ void HardwareMenu(){
     updateLine(settings, mainFont, lineTextBox[10], "EEPROM Test",            settings->lineXOffset, setLineYPos(9), WHITE);
     updateLine(settings, mainFont, lineTextBox[11], "Sprite Stress Test",     settings->lineXOffset, setLineYPos(10), WHITE);
 
-    updateLine(settings, mainFont, lineTextBox[12], "Help",              settings->lineXOffset, setLineYPos(11), WHITE);
-    updateLine(settings, mainFont, lineTextBox[13], "Options",           settings->lineXOffset, setLineYPos(12), WHITE);
-    updateLine(settings, mainFont, lineTextBox[14], "Back to Main Menu", settings->lineXOffset, setLineYPos(13), WHITE);
+    updateLine(settings, mainFont, lineTextBox[12], "Help",              settings->lineXOffset, setLineYPos(12), WHITE);
+    updateLine(settings, mainFont, lineTextBox[13], "Options",           settings->lineXOffset, setLineYPos(13), WHITE);
+    updateLine(settings, mainFont, lineTextBox[14], "Back to Main Menu", settings->lineXOffset, setLineYPos(14), WHITE);
     
     updateLine(settings, mainFont, lineTextBox[0], settings->PALNTSC ? "NTSC VDP 320x240p" : "PAL VDP 320x288p", 184, 200 + settings->PALOffset, WHITE);
        

--- a/scripts/screenshot-tour.py
+++ b/scripts/screenshot-tour.py
@@ -221,6 +221,26 @@ TOUR: list[TourGroup] = [
         ],
     ),
     TourGroup(
+        slug="cd-probe",
+        title="Jaguar CD Probe",
+        steps=[
+            ## Hardware Tools sub-menu, walk DOWN x7 to land on
+            ## "Jaguar CD Probe" (case 8). Capture the probe screen,
+            ## then press A to enter Memory Track Test (layer 12) and
+            ## capture that too -- verifies neither screen bleeds into
+            ## the other.
+            *_boot(),
+            *_open_main_item(3),
+            *(s for _ in range(7) for s in (_press("down"), _settle(8))),
+            _press("a"),
+            _settle(),
+            _capture("cd-probe", "Jaguar CD Probe register view"),
+            _press("a"),
+            _settle(),
+            _capture("memory-track", "Memory Track Test (from CD Probe)"),
+        ],
+    ),
+    TourGroup(
         slug="sprite-stress",
         title="Sprite stress test",
         steps=[


### PR DESCRIPTION
## Summary

- **Memory Track Test (closes #22):** Full 93C46 EEPROM read/write/verify test for the Jaguar CD's Memory Track save storage. Shares the cart EEPROM driver (un-static'd 4 functions in `eeprom_test.c`) and hex formatting helpers (`hexbyte`, `hexword`, `formatGridRow`, `formatCursorLine`). Shows CD detection status via the shared `jagCdProbeDetect()` heuristic, offers walking-1s / address-as-data patterns, and restores original contents on exit. Accessed via **A button inside the Jaguar CD Probe** screen (not a standalone menu item) to keep the Hardware Tools menu at 14 entries.
- **Expanded CD Probe (closes #21):** Probes 6 Butch ASIC registers (`$F14000`–`$F1400A`, up from 4), 2 CD BIOS window words (`$800000`–`$800002`, up from 1), adds a BIOS presence detection line (FOUND/NOT FOUND), and applies `PALOffset` to all Y positions. Footer shows `A: Memory Track` entry point.
- Memory Track uses **layer 12** (CD Probe uses layer 13) so neither screen bleeds into the other.
- Help screen entries for both tests; Hardware menu `lineYOffset` lowered to 56 with visual gap before Help/Options/Back (matching Video Tests layout).
- Screenshot tour group added (`cd-probe`) that captures both the CD Probe and Memory Track screens to catch layer-bleed regressions.

## Test plan

- [x] `make docker-rom` — compiles cleanly (no new warnings)
- [x] `make test` — libretro boot smoke test passes (60 frames, no crash)
- [x] `make verify-sig` — fastboot signature matches upstream
- [x] Manual: Hardware Tools → Jaguar CD Probe → press A → Memory Track Test renders alone (no CD Probe bleed-through)
- [x] Manual: Memory Track Test — run walking-1s (A) and address-as-data (X), verify grid updates and restore on exit
- [x] Manual: Jaguar CD Probe — verify all 8 register lines + BIOS line display correctly
- [x] Manual: verify DOWN+OPTION help works in both screens
- [x] Manual: confirm Hardware Tools menu fits on screen (14 items, "Back to Main Menu" not clipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)