### PR TITLE
release: bump version to 1.2.0

### DIFF
--- a/main.c
+++ b/main.c
@@ -1397,7 +1397,7 @@ void drawCredits(){
                     updateLine(settings, mainFont, lineTextBox[16], "Advisor:", settings->lineXOffset, setLineYPos(15), GREEN);
                     updateLine(settings, mainFont, lineTextBox[17], "  ()  ", settings->lineXOffset, setLineYPos(16), WHITE);
 
-                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 1.1.0 - 04/27/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
+                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 1.2.0 - 04/27/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
 
                     updateLine(settings, mainFont, lineTextBox[19], "Option - Return To Main Menu", settings->lineXOffset, setLineYPos(18) + 4, WHITE);
                 break;


### PR DESCRIPTION
## Summary
- Bump credits version string from 1.1.0 to 1.2.0 for the Memory Track Test + expanded CD Probe release.

## Test plan
- [x] Version string updated in `main.c` `drawCredits()`
- [ ] Tag `v1.2.0` after merge to trigger `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)