### PR TITLE
feat(hw): add JagLink Test to Hardware Tools menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ or substantially rewritten by this fork:
 | Test Patterns | More Patterns sub-menu (Color Bars w/ Gray, Linearity, Phase, Brightness, Contrast) |
 | Video Tests | Striped Sprite, Manual Lag Test, Alternate 240p/480i |
 | Audio Tests | L/R Balance + 1 kHz Tone, MDFourier Sweep |
-| Hardware Tools | Pro Controller Test, Rotary Controller Test, System Info, Jaguar CD Probe, Video Mode Test (Resolution Switching), EEPROM Read & Write Test (93C46) |
+| Hardware Tools | Pro Controller Test, Rotary Controller Test, System Info, Jaguar CD Probe, Video Mode Test (Resolution Switching), EEPROM Read & Write Test (93C46), JagLink Test |
 | Screen Savers | Color Cycle, Bouncing Square, Scrolling Bars |
 
 Procedurally generated wherever possible (see `extra_tests.c`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ or substantially rewritten by this fork:
 | Test Patterns | More Patterns sub-menu (Color Bars w/ Gray, Linearity, Phase, Brightness, Contrast) |
 | Video Tests | Striped Sprite, Manual Lag Test, Alternate 240p/480i |
 | Audio Tests | L/R Balance + 1 kHz Tone, MDFourier Sweep |
-| Hardware Tools | Pro Controller Test, Rotary Controller Test, System Info, Jaguar CD Probe, Video Mode Test (Resolution Switching), EEPROM Read & Write Test (93C46), JagLink Test |
+| Hardware Tools | Pro Controller Test, Rotary Controller Test, System Info, Jaguar CD Probe, Video Mode Test (Resolution Switching), EEPROM Read & Write Test (93C46), Sprite Stress Test, JagLink Test |
 | Screen Savers | Color Cycle, Bouncing Square, Scrolling Bars |
 
 Procedurally generated wherever possible (see `extra_tests.c`,

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Tests are grouped into five top-level menus. Items in **bold** were added or sub
 | **Test Patterns** | Pluge · Color Bars · EBU Color Bars · SMPTE Color Bars · Referenced Color Bars · Color Bleed Check · Monoscope · Grid · Gray Ramp · White & RGB Screens · 100 IRE · Sharpness · Overscan · Convergence · **More Patterns →** (**Color Bars w/ Gray** · **Linearity** · **Phase** · **Brightness** · **Contrast** · **Y/C Delay** · **Diagonal**) |
 | **Video Tests** | Drop Shadow · **Striped Sprite** · Lag Test · **Manual Lag Test** · Timing & Reflex · Scroll · **Vertical Scroll** · Grid Scroll · Horiz/Vert Stripes · Checkerboard · Backlight Zone · **Alternate 240p/480i** |
 | **Audio Tests** | Sound Test · Audio Sync · **L/R Balance + 1 kHz Tone** · **MDFourier Sweep** |
-| **Hardware Tools** | Controller Test · **Pro Controller Test** · **Rotary Controller Test** · GPU Memory Viewer · DSP Memory Viewer · DRAM Memory Viewer · **System Info** · **Jaguar CD Probe** · **Video Mode Test** (Resolution Switching) · **JagLink Test** |
+| **Hardware Tools** | Controller Test · **Pro Controller Test** · **Rotary Controller Test** · GPU Memory Viewer · DSP Memory Viewer · DRAM Memory Viewer · **System Info** · **Jaguar CD Probe** · **Video Mode Test** (Resolution Switching) · **EEPROM Test** · **Sprite Stress Test** · **JagLink Test** |
 | **Screen Savers** | **Color Cycle** · **Bouncing Square** · **Scrolling Bars** |
 
 In-app **Help** screens (per menu and per test) document the purpose, expected output, and any test-specific button bindings.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Tests are grouped into five top-level menus. Items in **bold** were added or sub
 | **Test Patterns** | Pluge · Color Bars · EBU Color Bars · SMPTE Color Bars · Referenced Color Bars · Color Bleed Check · Monoscope · Grid · Gray Ramp · White & RGB Screens · 100 IRE · Sharpness · Overscan · Convergence · **More Patterns →** (**Color Bars w/ Gray** · **Linearity** · **Phase** · **Brightness** · **Contrast** · **Y/C Delay** · **Diagonal**) |
 | **Video Tests** | Drop Shadow · **Striped Sprite** · Lag Test · **Manual Lag Test** · Timing & Reflex · Scroll · **Vertical Scroll** · Grid Scroll · Horiz/Vert Stripes · Checkerboard · Backlight Zone · **Alternate 240p/480i** |
 | **Audio Tests** | Sound Test · Audio Sync · **L/R Balance + 1 kHz Tone** · **MDFourier Sweep** |
-| **Hardware Tools** | Controller Test · **Pro Controller Test** · **Rotary Controller Test** · GPU Memory Viewer · DSP Memory Viewer · DRAM Memory Viewer · **System Info** · **Jaguar CD Probe** · **Video Mode Test** (Resolution Switching) |
+| **Hardware Tools** | Controller Test · **Pro Controller Test** · **Rotary Controller Test** · GPU Memory Viewer · DSP Memory Viewer · DRAM Memory Viewer · **System Info** · **Jaguar CD Probe** · **Video Mode Test** (Resolution Switching) · **JagLink Test** |
 | **Screen Savers** | **Color Cycle** · **Bouncing Square** · **Scrolling Bars** |
 
 In-app **Help** screens (per menu and per test) document the purpose, expected output, and any test-specific button bindings.

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -1945,6 +1945,28 @@ static void extraHighlightJagCdFooterLine(textBox *tb){
     textRangeColorChange(tb, start, plen, GREY, GREEN);
 }
 
+static void jagSetHex2(textBox *tb, char *buf, uint8_t v){
+    int n, i, hexStart, cmax;
+    if(tb == NULL || tb->text == NULL){ return; }
+    itostring(buf, (int)v, 16);
+    n = 0;
+    while(buf[n] != '\0' && n < 2) n++;
+    cmax = tb->char_count;
+    hexStart = 10;
+    {
+        int j = 0;
+        while(j < cmax && tb->text[j] != '\0' && tb->text[j] != ':') j++;
+        if(j < cmax && tb->text[j] == ':'){
+            j++;
+            while(j < cmax && tb->text[j] == ' ') j++;
+            if(j + 2 <= cmax) hexStart = j;
+        }
+    }
+    if(hexStart + 2 > cmax) return;
+    for(i = 0; i < 2 - n; i++) tb->text[hexStart + i] = '0';
+    for(i = 0; i < n; i++) tb->text[hexStart + (2 - n) + i] = buf[i];
+}
+
 static void jagCdSetHex4(textBox *tb, char *buf, uint16_t v){
     int n, i, pad, j, hexStart, cmax;
     if(tb == NULL || tb->text == NULL){ return; }
@@ -2416,10 +2438,11 @@ void MemoryTrackTest(void){
  *   ASICTRL  $F10032  — control and status register
  *   ASICLK   $F10034  — baud-rate clock divider
  *
- * On a base Jaguar with nothing connected these registers read 0x00 or
- * 0xFF (open bus). Any other value suggests a JagLink or compatible
- * serial device is present. The loopback sub-test writes 0xA5 to ASIDATA
- * and reads it back after a short spin to check basic TX→RX wiring.
+ * All three are 16-bit registers on the Jerry bus (confirmed by VJ source).
+ * On a base Jaguar with nothing connected they read 0x0000 or 0xFFFF
+ * (open bus). Any other value suggests a JagLink or compatible serial
+ * device is present. The loopback sub-test writes 0xA5 into the data
+ * byte and reads it back after a short spin to check basic TX→RX wiring.
  * --------------------------------------------------------------------------- */
 void JagLinkTest(void){
     int exit = 0;
@@ -2433,26 +2456,26 @@ void JagLinkTest(void){
 
     int palY = settings->PALOffset;
 
-    volatile uint8_t *asidata = (volatile uint8_t *)0xF10030;
-    volatile uint8_t *asictrl = (volatile uint8_t *)0xF10032;
-    volatile uint8_t *asiclk  = (volatile uint8_t *)0xF10034;
+    volatile uint16_t *asidata = (volatile uint16_t *)0xF10030;
+    volatile uint16_t *asictrl = (volatile uint16_t *)0xF10032;
+    volatile uint16_t *asiclk  = (volatile uint16_t *)0xF10034;
 
-    uint8_t vData, vCtrl, vClk;
+    uint16_t vData, vCtrl, vClk;
 
     textBox *titleTb  = newTextBox("JAGLINK TEST       ", 192, 9, mainFont, 0, settings->d, 80, 24 + palY, 13, 1);
     updateLine(settings, mainFont, titleTb, NULL, 999999, 999999, GREEN);
 
     textBox *statusTb = newTextBox("STATUS  : NOT DETECTED  ", 256, 9, mainFont, 0, settings->d, 48, 44 + palY, 13, 1);
-    textBox *dataTb   = newTextBox("ASIDATA : 00   ($F10030)", 256, 9, mainFont, 0, settings->d, 48, 62 + palY, 13, 1);
-    textBox *ctrlTb   = newTextBox("ASICTRL : 00   ($F10032)", 256, 9, mainFont, 0, settings->d, 48, 76 + palY, 13, 1);
-    textBox *clkTb    = newTextBox("ASICLK  : 00   ($F10034)", 256, 9, mainFont, 0, settings->d, 48, 90 + palY, 13, 1);
+    textBox *dataTb   = newTextBox("ASIDATA : 0000 ($F10030)", 256, 9, mainFont, 0, settings->d, 48, 62 + palY, 13, 1);
+    textBox *ctrlTb   = newTextBox("ASICTRL : 0000 ($F10032)", 256, 9, mainFont, 0, settings->d, 48, 76 + palY, 13, 1);
+    textBox *clkTb    = newTextBox("ASICLK  : 0000 ($F10034)", 256, 9, mainFont, 0, settings->d, 48, 90 + palY, 13, 1);
 
     textBox *loopTitleTb = newTextBox("LOOPBACK TEST            ", 256, 9, mainFont, 0, settings->d, 48, 114 + palY, 13, 1);
-    textBox *loopTxTb    = newTextBox("TX BYTE : 0xA5           ", 256, 9, mainFont, 0, settings->d, 48, 128 + palY, 13, 1);
+    textBox *loopTxTb    = newTextBox("TX BYTE : A5             ", 256, 9, mainFont, 0, settings->d, 48, 128 + palY, 13, 1);
     textBox *loopRxTb    = newTextBox("RX BYTE : --             ", 256, 9, mainFont, 0, settings->d, 48, 142 + palY, 13, 1);
     textBox *loopResTb   = newTextBox("RESULT  : not run        ", 256, 9, mainFont, 0, settings->d, 48, 156 + palY, 13, 1);
 
-    textBox *noteTb = newTextBox("LIVE/frm: hex refresh  00+FF=open bus", 256, 9, mainFont, 0, settings->d, 16, 186 + palY, 13, 1);
+    textBox *noteTb = newTextBox("LIVE/frm: hex refresh 0000+FFFF=open", 256, 9, mainFont, 0, settings->d, 16, 186 + palY, 13, 1);
     textBox *helpTb = newTextBox("A: loopback  DOWN+OPTION: help  OPT: exit", 320, 9, mainFont, 0, settings->d, 0, 204 + palY, 13, 1);
     updateLine(settings, mainFont, loopTitleTb, NULL, 999999, 999999, GREEN);
     updateLine(settings, mainFont, loopTxTb, NULL, 999999, 999999, WHITE);
@@ -2482,15 +2505,15 @@ void JagLinkTest(void){
         if((settings->joy1 & JOYPAD_A) && settings->controllerLock == 0){
             settings->controllerLock = 1;
 
-            *asiclk  = 0x02;
-            *asictrl = 0x01;
-            *asidata = txByte;
+            *asiclk  = 0x0002;
+            *asictrl = 0x0001;
+            *asidata = (uint16_t)txByte;
 
             for(i = 0; i < 2000; i++){
                 __asm__ volatile("nop");
             }
 
-            rxByte = *asidata;
+            rxByte = (uint8_t)(*asidata & 0xFF);
             loopbackRun = 1;
             loopbackPass = (rxByte == txByte) ? 1 : 0;
         }
@@ -2500,9 +2523,9 @@ void JagLinkTest(void){
         }
 
         detected = 0;
-        if(vData != 0x00U && vData != 0xFFU) detected = 1;
-        if(vCtrl != 0x00U && vCtrl != 0xFFU) detected = 1;
-        if(vClk  != 0x00U && vClk  != 0xFFU) detected = 1;
+        if(vData != 0x0000U && vData != 0xFFFFU) detected = 1;
+        if(vCtrl != 0x0000U && vCtrl != 0xFFFFU) detected = 1;
+        if(vClk  != 0x0000U && vClk  != 0xFFFFU) detected = 1;
 
         if(detected){
             const char *yes = "DETECTED      ";
@@ -2513,45 +2536,15 @@ void JagLinkTest(void){
         }
         updateLine(settings, mainFont, statusTb, NULL, 999999, 999999, detected ? GREEN : RED);
 
-        {
-            int hexOff = 10;
-            itostring(buf, (int)vData, 16);
-            int n = 0;
-            while(buf[n] != '\0' && n < 2) n++;
-            for(i = 0; i < 2 - n; i++) dataTb->text[hexOff + i] = '0';
-            for(i = 0; i < n; i++) dataTb->text[hexOff + (2 - n) + i] = buf[i];
-        }
+        jagCdSetHex4(dataTb, buf, vData);
         updateLine(settings, mainFont, dataTb, NULL, 999999, 999999, WHITE);
-
-        {
-            int hexOff = 10;
-            itostring(buf, (int)vCtrl, 16);
-            int n = 0;
-            while(buf[n] != '\0' && n < 2) n++;
-            for(i = 0; i < 2 - n; i++) ctrlTb->text[hexOff + i] = '0';
-            for(i = 0; i < n; i++) ctrlTb->text[hexOff + (2 - n) + i] = buf[i];
-        }
+        jagCdSetHex4(ctrlTb, buf, vCtrl);
         updateLine(settings, mainFont, ctrlTb, NULL, 999999, 999999, WHITE);
-
-        {
-            int hexOff = 10;
-            itostring(buf, (int)vClk, 16);
-            int n = 0;
-            while(buf[n] != '\0' && n < 2) n++;
-            for(i = 0; i < 2 - n; i++) clkTb->text[hexOff + i] = '0';
-            for(i = 0; i < n; i++) clkTb->text[hexOff + (2 - n) + i] = buf[i];
-        }
+        jagCdSetHex4(clkTb, buf, vClk);
         updateLine(settings, mainFont, clkTb, NULL, 999999, 999999, WHITE);
 
         if(loopbackRun){
-            {
-                int hexOff = 10;
-                itostring(buf, (int)rxByte, 16);
-                int n = 0;
-                while(buf[n] != '\0' && n < 2) n++;
-                for(i = 0; i < 2 - n; i++) loopRxTb->text[hexOff + i] = '0';
-                for(i = 0; i < n; i++) loopRxTb->text[hexOff + (2 - n) + i] = buf[i];
-            }
+            jagSetHex2(loopRxTb, buf, rxByte);
             updateLine(settings, mainFont, loopRxTb, NULL, 999999, 999999, WHITE);
 
             if(loopbackPass){

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -2503,7 +2503,11 @@ void JagLinkTest(void){
             DrawHelp(HELP_JAGLINK_TEST);
         }
         if((settings->joy1 & JOYPAD_A) && settings->controllerLock == 0){
+            uint16_t savedClk, savedCtrl;
             settings->controllerLock = 1;
+
+            savedClk  = *asiclk;
+            savedCtrl = *asictrl;
 
             *asiclk  = 0x0002;
             *asictrl = 0x0001;
@@ -2516,6 +2520,9 @@ void JagLinkTest(void){
             rxByte = (uint8_t)(*asidata & 0xFF);
             loopbackRun = 1;
             loopbackPass = (rxByte == txByte) ? 1 : 0;
+
+            *asictrl = savedCtrl;
+            *asiclk  = savedClk;
         }
         if(extraExitPressed()){
             settings->controllerLock = 1;

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -2473,7 +2473,7 @@ void JagLinkTest(void){
     textBox *loopTitleTb = newTextBox("LOOPBACK TEST            ", 256, 9, mainFont, 0, settings->d, 48, 114 + palY, 13, 1);
     textBox *loopTxTb    = newTextBox("TX BYTE : A5             ", 256, 9, mainFont, 0, settings->d, 48, 128 + palY, 13, 1);
     textBox *loopRxTb    = newTextBox("RX BYTE : --             ", 256, 9, mainFont, 0, settings->d, 48, 142 + palY, 13, 1);
-    textBox *loopResTb   = newTextBox("RESULT  : not run        ", 256, 9, mainFont, 0, settings->d, 48, 156 + palY, 13, 1);
+    textBox *loopResTb   = newTextBox("RESULT  : not run           ", 256, 9, mainFont, 0, settings->d, 48, 156 + palY, 13, 1);
 
     textBox *noteTb = newTextBox("LIVE/frm: hex refresh 0000+FFFF=open", 256, 9, mainFont, 0, settings->d, 16, 186 + palY, 13, 1);
     textBox *helpTb = newTextBox("A: loopback  DOWN+OPTION: help  OPT: exit", 320, 9, mainFont, 0, settings->d, 0, 204 + palY, 13, 1);

--- a/extra_tests.c
+++ b/extra_tests.c
@@ -2409,6 +2409,178 @@ void MemoryTrackTest(void){
 }
 
 /* ---------------------------------------------------------------------------
+ * JagLink Test — Jerry UART register probe + loopback
+ *
+ * The JagLink network adapter uses Jerry's asynchronous serial interface:
+ *   ASIDATA  $F10030  — transmit/receive data (active bits vary by mode)
+ *   ASICTRL  $F10032  — control and status register
+ *   ASICLK   $F10034  — baud-rate clock divider
+ *
+ * On a base Jaguar with nothing connected these registers read 0x00 or
+ * 0xFF (open bus). Any other value suggests a JagLink or compatible
+ * serial device is present. The loopback sub-test writes 0xA5 to ASIDATA
+ * and reads it back after a short spin to check basic TX→RX wiring.
+ * --------------------------------------------------------------------------- */
+void JagLinkTest(void){
+    int exit = 0;
+    int loopbackRun = 0;
+    int loopbackPass = 0;
+    uint8_t txByte = 0xA5;
+    uint8_t rxByte = 0x00;
+    char buf[12] = "00000000\0";
+    int i;
+    int detected;
+
+    int palY = settings->PALOffset;
+
+    volatile uint8_t *asidata = (volatile uint8_t *)0xF10030;
+    volatile uint8_t *asictrl = (volatile uint8_t *)0xF10032;
+    volatile uint8_t *asiclk  = (volatile uint8_t *)0xF10034;
+
+    uint8_t vData, vCtrl, vClk;
+
+    textBox *titleTb  = newTextBox("JAGLINK TEST       ", 192, 9, mainFont, 0, settings->d, 80, 24 + palY, 13, 1);
+    updateLine(settings, mainFont, titleTb, NULL, 999999, 999999, GREEN);
+
+    textBox *statusTb = newTextBox("STATUS  : NOT DETECTED  ", 256, 9, mainFont, 0, settings->d, 48, 44 + palY, 13, 1);
+    textBox *dataTb   = newTextBox("ASIDATA : 00   ($F10030)", 256, 9, mainFont, 0, settings->d, 48, 62 + palY, 13, 1);
+    textBox *ctrlTb   = newTextBox("ASICTRL : 00   ($F10032)", 256, 9, mainFont, 0, settings->d, 48, 76 + palY, 13, 1);
+    textBox *clkTb    = newTextBox("ASICLK  : 00   ($F10034)", 256, 9, mainFont, 0, settings->d, 48, 90 + palY, 13, 1);
+
+    textBox *loopTitleTb = newTextBox("LOOPBACK TEST            ", 256, 9, mainFont, 0, settings->d, 48, 114 + palY, 13, 1);
+    textBox *loopTxTb    = newTextBox("TX BYTE : 0xA5           ", 256, 9, mainFont, 0, settings->d, 48, 128 + palY, 13, 1);
+    textBox *loopRxTb    = newTextBox("RX BYTE : --             ", 256, 9, mainFont, 0, settings->d, 48, 142 + palY, 13, 1);
+    textBox *loopResTb   = newTextBox("RESULT  : not run        ", 256, 9, mainFont, 0, settings->d, 48, 156 + palY, 13, 1);
+
+    textBox *noteTb = newTextBox("LIVE/frm: hex refresh  00+FF=open bus", 256, 9, mainFont, 0, settings->d, 16, 186 + palY, 13, 1);
+    textBox *helpTb = newTextBox("A: loopback  DOWN+OPTION: help  OPT: exit", 320, 9, mainFont, 0, settings->d, 0, 204 + palY, 13, 1);
+    updateLine(settings, mainFont, loopTitleTb, NULL, 999999, 999999, GREEN);
+    updateLine(settings, mainFont, loopTxTb, NULL, 999999, 999999, WHITE);
+    updateLine(settings, mainFont, loopRxTb, NULL, 999999, 999999, WHITE);
+    updateLine(settings, mainFont, loopResTb, NULL, 999999, 999999, GREY);
+    updateLine(settings, mainFont, noteTb, NULL, 999999, 999999, GREY);
+    updateLine(settings, mainFont, helpTb, NULL, 999999, 999999, GREY);
+    extraHighlightJagCdFooterLine(helpTb);
+
+    hide_or_show_display_layer_range(settings->d, 1, 3, 15);
+
+    while(!exit){
+        read_joypad_state(settings->j_state);
+        settings->joy1 = settings->j_state->j1;
+        vData = *asidata;
+        vCtrl = *asictrl;
+        vClk  = *asiclk;
+        vsync();
+
+        if((settings->joy1 & 0xFFFFFF) == 0){
+            settings->controllerLock = 0;
+        }
+        if(((settings->joy1 & JOYPAD_DOWN) && (settings->joy1 & JOYPAD_OPTION)) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+            DrawHelp(HELP_JAGLINK_TEST);
+        }
+        if((settings->joy1 & JOYPAD_A) && settings->controllerLock == 0){
+            settings->controllerLock = 1;
+
+            *asiclk  = 0x02;
+            *asictrl = 0x01;
+            *asidata = txByte;
+
+            for(i = 0; i < 2000; i++){
+                __asm__ volatile("nop");
+            }
+
+            rxByte = *asidata;
+            loopbackRun = 1;
+            loopbackPass = (rxByte == txByte) ? 1 : 0;
+        }
+        if(extraExitPressed()){
+            settings->controllerLock = 1;
+            exit = 1;
+        }
+
+        detected = 0;
+        if(vData != 0x00U && vData != 0xFFU) detected = 1;
+        if(vCtrl != 0x00U && vCtrl != 0xFFU) detected = 1;
+        if(vClk  != 0x00U && vClk  != 0xFFU) detected = 1;
+
+        if(detected){
+            const char *yes = "DETECTED      ";
+            for(i = 0; i < 14; i++){ statusTb->text[10 + i] = yes[i]; }
+        } else {
+            const char *no = "NOT DETECTED  ";
+            for(i = 0; i < 14; i++){ statusTb->text[10 + i] = no[i]; }
+        }
+        updateLine(settings, mainFont, statusTb, NULL, 999999, 999999, detected ? GREEN : RED);
+
+        {
+            int hexOff = 10;
+            itostring(buf, (int)vData, 16);
+            int n = 0;
+            while(buf[n] != '\0' && n < 2) n++;
+            for(i = 0; i < 2 - n; i++) dataTb->text[hexOff + i] = '0';
+            for(i = 0; i < n; i++) dataTb->text[hexOff + (2 - n) + i] = buf[i];
+        }
+        updateLine(settings, mainFont, dataTb, NULL, 999999, 999999, WHITE);
+
+        {
+            int hexOff = 10;
+            itostring(buf, (int)vCtrl, 16);
+            int n = 0;
+            while(buf[n] != '\0' && n < 2) n++;
+            for(i = 0; i < 2 - n; i++) ctrlTb->text[hexOff + i] = '0';
+            for(i = 0; i < n; i++) ctrlTb->text[hexOff + (2 - n) + i] = buf[i];
+        }
+        updateLine(settings, mainFont, ctrlTb, NULL, 999999, 999999, WHITE);
+
+        {
+            int hexOff = 10;
+            itostring(buf, (int)vClk, 16);
+            int n = 0;
+            while(buf[n] != '\0' && n < 2) n++;
+            for(i = 0; i < 2 - n; i++) clkTb->text[hexOff + i] = '0';
+            for(i = 0; i < n; i++) clkTb->text[hexOff + (2 - n) + i] = buf[i];
+        }
+        updateLine(settings, mainFont, clkTb, NULL, 999999, 999999, WHITE);
+
+        if(loopbackRun){
+            {
+                int hexOff = 10;
+                itostring(buf, (int)rxByte, 16);
+                int n = 0;
+                while(buf[n] != '\0' && n < 2) n++;
+                for(i = 0; i < 2 - n; i++) loopRxTb->text[hexOff + i] = '0';
+                for(i = 0; i < n; i++) loopRxTb->text[hexOff + (2 - n) + i] = buf[i];
+            }
+            updateLine(settings, mainFont, loopRxTb, NULL, 999999, 999999, WHITE);
+
+            if(loopbackPass){
+                const char *p = "PASS             ";
+                for(i = 0; i < 17; i++){ loopResTb->text[10 + i] = p[i]; }
+                updateLine(settings, mainFont, loopResTb, NULL, 999999, 999999, GREEN);
+            } else {
+                const char *f = "FAIL (mismatch)  ";
+                for(i = 0; i < 17; i++){ loopResTb->text[10 + i] = f[i]; }
+                updateLine(settings, mainFont, loopResTb, NULL, 999999, 999999, RED);
+            }
+        }
+    }
+
+    hide_or_show_display_layer_range(settings->d, 0, 3, 15);
+    helpTb       = freeTextBox(helpTb);
+    noteTb       = freeTextBox(noteTb);
+    loopResTb    = freeTextBox(loopResTb);
+    loopRxTb     = freeTextBox(loopRxTb);
+    loopTxTb     = freeTextBox(loopTxTb);
+    loopTitleTb  = freeTextBox(loopTitleTb);
+    clkTb        = freeTextBox(clkTb);
+    ctrlTb       = freeTextBox(ctrlTb);
+    dataTb       = freeTextBox(dataTb);
+    statusTb     = freeTextBox(statusTb);
+    titleTb      = freeTextBox(titleTb);
+}
+
+/* ---------------------------------------------------------------------------
  * Screen Saver: Color Cycle
  *
  * Pure background-color sweep through the HSV-ish hue space using TOM's

--- a/extra_tests.h
+++ b/extra_tests.h
@@ -60,6 +60,7 @@ void ChannelSeparationTest(void);
 void HardwareInfo(void);
 void JaguarCDTest(void);
 void MemoryTrackTest(void);
+void JagLinkTest(void);
 void ResolutionTest(void);
 void ProControllerTest(void);
 void RotaryControllerTest(void);

--- a/help.c
+++ b/help.c
@@ -109,6 +109,7 @@ void DrawHelp(int option){
         case HELP_CHANNEL_SEP:
         case HELP_JAGUAR_CD:
         case HELP_MEMORY_TRACK:
+        case HELP_JAGLINK_TEST:
             totalPages = 1;
         break;
 
@@ -654,6 +655,20 @@ void DrawHelp(int option){
                             updateLine(settings, mainFont, helpLineTextBox[0], "MEMORY TRACK TEST", 999999, 999999, GREEN);
 
                             updateLine(settings, mainFont, helpTextBox, "Exercises the 93C46 serial EEPROM on the bus. On a Jaguar CD with Memory Track this is the CD unit's 128-byte save storage. Without a CD this tests the cart's own EEPROM.^The CD line shows whether CD hardware was detected. Both EEPROMs use the same Jerry bus ($F14001/$F14801/$F15001).^^A: Walking-1s   X: Address-as-data^B: Re-read   Y: Erase cell^OPTION: restore originals and exit^DOWN+OPTION: this help", 999999, 999999, WHITE);
+                            highlightHelpPhrase(helpTextBox, "DOWN+OPTION");
+                        break;
+                    }
+
+                break;
+
+                case HELP_JAGLINK_TEST:
+
+                    switch(page){
+
+                        case 0:
+                            updateLine(settings, mainFont, helpLineTextBox[0], "JAGLINK TEST", 999999, 999999, GREEN);
+
+                            updateLine(settings, mainFont, helpTextBox, "Probes the Jerry UART registers used by the JagLink network adapter. ASIDATA ($F10030) is the data register, ASICTRL ($F10032) the control/status register, and ASICLK ($F10034) the baud-rate clock divider.^On a base Jaguar these read 0x00 or 0xFF (open bus). Any other value suggests a JagLink or compatible serial device is present.^^A: loopback test (writes 0xA5, reads back)^DOWN+OPTION: this help   OPTION: exit", 999999, 999999, WHITE);
                             highlightHelpPhrase(helpTextBox, "DOWN+OPTION");
                         break;
                     }

--- a/help.c
+++ b/help.c
@@ -668,7 +668,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "JAGLINK TEST", 999999, 999999, GREEN);
 
-                            updateLine(settings, mainFont, helpTextBox, "Probes the Jerry UART registers used by the JagLink network adapter. ASIDATA ($F10030) is the data register, ASICTRL ($F10032) the control/status register, and ASICLK ($F10034) the baud-rate clock divider.^On a base Jaguar these read 0x00 or 0xFF (open bus). Any other value suggests a JagLink or compatible serial device is present.^^A: loopback test (writes 0xA5, reads back)^DOWN+OPTION: this help   OPTION: exit", 999999, 999999, WHITE);
+                            updateLine(settings, mainFont, helpTextBox, "Probes the Jerry UART registers used by the JagLink network adapter. ASIDATA ($F10030) is the 16-bit data register, ASICTRL ($F10032) the control/status register, and ASICLK ($F10034) the baud-rate clock divider.^On a base Jaguar these read 0x0000 or 0xFFFF (open bus). Any other value suggests a JagLink or compatible serial device is present.^^A: loopback test (writes 0xA5, reads back)^DOWN+OPTION: this help   OPTION: exit", 999999, 999999, WHITE);
                             highlightHelpPhrase(helpTextBox, "DOWN+OPTION");
                         break;
                     }

--- a/help.c
+++ b/help.c
@@ -668,7 +668,7 @@ void DrawHelp(int option){
                         case 0:
                             updateLine(settings, mainFont, helpLineTextBox[0], "JAGLINK TEST", 999999, 999999, GREEN);
 
-                            updateLine(settings, mainFont, helpTextBox, "Probes the Jerry UART registers used by the JagLink network adapter. ASIDATA ($F10030) is the 16-bit data register, ASICTRL ($F10032) the control/status register, and ASICLK ($F10034) the baud-rate clock divider.^On a base Jaguar these read 0x0000 or 0xFFFF (open bus). Any other value suggests a JagLink or compatible serial device is present.^^A: loopback test (writes 0xA5, reads back)^DOWN+OPTION: this help   OPTION: exit", 999999, 999999, WHITE);
+                            updateLine(settings, mainFont, helpTextBox, "Probes the Jerry UART registers used by the JagLink network adapter. ASIDATA ($F10030) is the 16-bit data register, ASICTRL ($F10032) the control/status register, and ASICLK ($F10034) the baud-rate clock divider.^On a base Jaguar these read 0x0000 or 0xFFFF (open bus). Any other value suggests a JagLink or compatible serial device is present.^Limitations: this probe and the loopback test do not validate a full JagLink session/protocol. Open-bus heuristics can also give false positives or false negatives depending on hardware or emulator behavior.^^A: loopback test (writes 0xA5, reads back)^DOWN+OPTION: this help   OPTION: exit", 999999, 999999, WHITE);
                             highlightHelpPhrase(helpTextBox, "DOWN+OPTION");
                         break;
                     }

--- a/help.h
+++ b/help.h
@@ -55,6 +55,7 @@
 #define HELP_CHANNEL_SEP 39
 #define HELP_JAGUAR_CD 40
 #define HELP_MEMORY_TRACK 41
+#define HELP_JAGLINK_TEST 42
 
 extern uint8_t help;
 phrase *helpData;

--- a/main.c
+++ b/main.c
@@ -1148,7 +1148,7 @@ void HardwareMenu(){
     /* Max 1-based menuState value (cursor wraps between 1 and
      * lastMenuLine). Memory Track is inside the CD Probe screen (A
      * button), not a standalone menu entry. */
-    int lastMenuLine = 14;
+    int lastMenuLine = 15;
     settings->menuState = 1;
     
     hide_display_layer(settings->d, 2);
@@ -1170,10 +1170,11 @@ void HardwareMenu(){
     updateLine(settings, mainFont, lineTextBox[9],  "Video Mode Test",        settings->lineXOffset, setLineYPos(8), WHITE);
     updateLine(settings, mainFont, lineTextBox[10], "EEPROM Test",            settings->lineXOffset, setLineYPos(9), WHITE);
     updateLine(settings, mainFont, lineTextBox[11], "Sprite Stress Test",     settings->lineXOffset, setLineYPos(10), WHITE);
+    updateLine(settings, mainFont, lineTextBox[12], "JagLink Test",           settings->lineXOffset, setLineYPos(11), WHITE);
 
-    updateLine(settings, mainFont, lineTextBox[12], "Help",              settings->lineXOffset, setLineYPos(12), WHITE);
-    updateLine(settings, mainFont, lineTextBox[13], "Options",           settings->lineXOffset, setLineYPos(13), WHITE);
-    updateLine(settings, mainFont, lineTextBox[14], "Back to Main Menu", settings->lineXOffset, setLineYPos(14), WHITE);
+    updateLine(settings, mainFont, lineTextBox[13], "Help",              settings->lineXOffset, setLineYPos(13), WHITE);
+    updateLine(settings, mainFont, lineTextBox[14], "Options",           settings->lineXOffset, setLineYPos(14), WHITE);
+    updateLine(settings, mainFont, lineTextBox[15], "Back to Main Menu", settings->lineXOffset, setLineYPos(15), WHITE);
     
     updateLine(settings, mainFont, lineTextBox[0], settings->PALNTSC ? "NTSC VDP 320x240p" : "PAL VDP 320x288p", 184, 200 + settings->PALOffset, WHITE);
        
@@ -1313,8 +1314,15 @@ void HardwareMenu(){
 
                 break;
 
-                //Help
+                //JagLink Test (Jerry UART probe)
                 case 12:
+
+                    JagLinkTest();
+
+                break;
+
+                //Help
+                case 13:
 
                     hide_or_show_display_layer_range(settings->d, 0, 0, 15);
                     hide_or_show_display_layer_range(settings->d, 1, 14, 14);
@@ -1326,13 +1334,13 @@ void HardwareMenu(){
                 break;
 
                 //Options
-                case 13:
+                case 14:
 
                     OptionsMenu();
 
                 break;
 
-                case 14:
+                case 15:
 
                     done = 1;
 

--- a/scripts/screenshot-tour.py
+++ b/scripts/screenshot-tour.py
@@ -265,7 +265,7 @@ TOUR: list[TourGroup] = [
             ## Hardware Tools sub-menu, walk DOWN x11 to land on
             ## "JagLink Test" (lineTextBox[12], case 12). The test
             ## probes Jerry UART registers -- on a base Jaguar (and
-            ## emulators) all three read 0x00/0xFF so status shows
+            ## emulators) all three read 0x0000/0xFFFF so status shows
             ## NOT DETECTED, which is the expected screenshot.
             *_boot(),
             *_open_main_item(3),

--- a/scripts/screenshot-tour.py
+++ b/scripts/screenshot-tour.py
@@ -259,6 +259,23 @@ TOUR: list[TourGroup] = [
         ],
     ),
     TourGroup(
+        slug="jaglink",
+        title="JagLink test",
+        steps=[
+            ## Hardware Tools sub-menu, walk DOWN x11 to land on
+            ## "JagLink Test" (lineTextBox[12], case 12). The test
+            ## probes Jerry UART registers -- on a base Jaguar (and
+            ## emulators) all three read 0x00/0xFF so status shows
+            ## NOT DETECTED, which is the expected screenshot.
+            *_boot(),
+            *_open_main_item(3),
+            *(s for _ in range(11) for s in (_press("down"), _settle(8))),
+            _press("a"),
+            _settle(),
+            _capture("jaglink-probe", "JagLink Test (Jerry UART probe)"),
+        ],
+    ),
+    TourGroup(
         slug="ycdelay",
         title="Y/C delay pattern",
         steps=[


### PR DESCRIPTION
## Summary

- Adds **JagLink Test** to the Hardware Tools menu (slot 12), probing Jerry UART registers (`ASIDATA` $F10030, `ASICTRL` $F10032, `ASICLK` $F10034) used by the JagLink network adapter
- Live per-frame hex display with open-bus detection heuristic (same pattern as Jaguar CD Probe — values of 0x00/0xFF = open bus, anything else = detected)
- **Loopback sub-test** (A button): writes 0xA5, spins, reads back — verifies basic TX→RX wiring when a JagLink or compatible serial device is connected
- Help page, PALOffset on all Y positions, proper layer management, all textboxes freed on exit

Closes #20

## Test plan

- [ ] Verify ROM builds cleanly (`make docker-rom` — confirmed locally, zero new warnings)
- [ ] Verify fastboot signature (`make verify-sig` — confirmed locally)
- [ ] CI build passes (libretro smoke test)
- [ ] Menu navigation: JagLink Test appears at slot 12, Help/Options/Back correctly at 13/14/15
- [ ] On base Jaguar (no JagLink): all registers show 00 or FF, status shows NOT DETECTED
- [ ] With JagLink connected: registers show non-open-bus values, status shows DETECTED
- [ ] Loopback test (A button): shows PASS/FAIL with received byte
- [ ] Help screen (DOWN+OPTION): displays register descriptions and controls
- [ ] PAL mode: all text positions shifted correctly
- [ ] Exit (OPTION): returns cleanly to Hardware Tools menu, no layer bleed

🤖 Generated with [Claude Code](https://claude.com/claude-code)