### PR TITLE
release: bump version to 1.3.0 (JagLink Test)

### DIFF
--- a/main.c
+++ b/main.c
@@ -1405,7 +1405,7 @@ void drawCredits(){
                     updateLine(settings, mainFont, lineTextBox[16], "Advisor:", settings->lineXOffset, setLineYPos(15), GREEN);
                     updateLine(settings, mainFont, lineTextBox[17], "  ()  ", settings->lineXOffset, setLineYPos(16), WHITE);
 
-                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 1.2.1 - 04/27/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
+                    updateLine(settings, mainFont, lineTextBox[18], "                   Ver. 1.3.0 - 04/27/2026", settings->lineXOffset, setLineYPos(0) - 11, GREEN);
 
                     updateLine(settings, mainFont, lineTextBox[19], "Option - Return To Main Menu", settings->lineXOffset, setLineYPos(18) + 4, WHITE);
                 break;


### PR DESCRIPTION
## Summary

- Bumps version from 1.2.1 to 1.3.0 in `drawCredits()` to reflect the JagLink Test addition (PR #33)
- Minor version bump: new Hardware Tools menu entry (JagLink Test) is a user-visible feature

## Test plan

- [ ] CI build passes
- [ ] Credits screen shows "Ver. 1.3.0 - 04/27/2026"
- [ ] Tag `v1.3.0` after merge to trigger `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)